### PR TITLE
added missing encoding use case

### DIFF
--- a/docs/modules/json.md
+++ b/docs/modules/json.md
@@ -20,6 +20,7 @@ It contains the following classes:
 #### `static encode(object: Object, options:Num): String`
 
 Transform the object to a _Json_ encoded string. With default or custom options.
+Encoding only works for primitive data types (_String_, _List_, _Map_, _Num_, _Null_). If a non primitive object is passed, the encoder will call it's _toString_ method.
 
 #### `static decode(value:String, options:Num): Object`
 
@@ -38,6 +39,47 @@ Reads the contents of a file in `path` and returns a new _Json_ object with defa
 ### `static save(path: String, object:Object, options:Num)`
 
 This will encode the object and then save the result to a file specified in `path`. With default or custom options.
+
+### Examples
+
+#### Encoding a Simple Object
+
+A simple object made with only primitive data structures.
+
+```js
+Json.encode({
+ "is": true
+})
+```
+
+#### Encoding a Complex Object
+
+An object made with custom data structures.
+
+```js
+import "json" for Json
+
+class MyClass {
+  // override toString to provide a serializable representation
+  // of the object. This serialization will be called by the
+  // Json.encode() method.
+  toString {Json.encode(toMap)}
+  toMap {{
+    "is": isTrue
+  }}
+
+  isTrue {_isTrue}
+
+  construct new(isTrue) {
+  _isTrue = isTrue
+ }
+}
+
+var obj = MyClass.new(true)
+
+// prints: {"is":true}
+System.print(Json.encode(obj))
+```
 
 ## JsonOptions
 

--- a/docs/modules/json.md
+++ b/docs/modules/json.md
@@ -20,7 +20,7 @@ It contains the following classes:
 #### `static encode(object: Object, options:Num): String`
 
 Transform the object to a _Json_ encoded string. With default or custom options.
-Encoding only works for primitive data types (_String_, _List_, _Map_, _Num_, _Null_). If a non primitive object is passed, the encoder will call it's _toString_ method.
+Encoding only works for primitive data types (_Bool_, _Map_, _Num_, _Null_, _List_, _String_). If a non primitive object is passed, the encoder will call it's _toString_ method.
 
 #### `static decode(value:String, options:Num): Object`
 

--- a/src/modules/json.wren
+++ b/src/modules/json.wren
@@ -184,6 +184,9 @@ class Json {
       }
       return "{" + substrings.join(",") + "}"
     }
+
+    // Default behaviour is to invoke the toString method
+    return value.toString
   }
 
   static encode(value) {


### PR DESCRIPTION
When passing a custom class the encoder would fail
since it would return null.

This invokes the `toString` method in the object as the default encoding.