### PR TITLE
Image opacity property

### DIFF
--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -218,6 +218,7 @@ Options available are:
  * `scaleX`, `scaleY` - You can scale your image in the x and y axis, independant of each other. If either of these are negative, they result in a "flip" operation.
  * `angle` - Rotates the image. This is in degrees, and rounded to the nearest 90 degrees.
  * `opacity` - A number between 0.0 and 1.0, this sets the global opacity of this image. Any alpha values in the image will be multipled by this value,
+ * `tint` - A color value which is to be applied on top of the image. Use the tint color's alpha to control how strong the tint is.
  * `mode`, `foreground` and `background` - By default, mode is `"RGBA"`, so your images will draw in their true colors. If you set it to `"MONO"`, any pixels which are black or have transparency will be drawn in the `background` color and all other pixels of the image will be drawn in the `foreground` color. Both colors must be `Color` objects, and default to `Color.black` and `Color.white`, respectively.
 
 Transforms are applied as follows: Crop to the region, then rotate, then scale/flip.

--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -217,6 +217,7 @@ Options available are:
  * `srcW`, `srcH` - This is the width and height of the source image region you want to draw.
  * `scaleX`, `scaleY` - You can scale your image in the x and y axis, independant of each other. If either of these are negative, they result in a "flip" operation.
  * `angle` - Rotates the image. This is in degrees, and rounded to the nearest 90 degrees.
+ * `opacity` - A number between 0.0 and 1.0, this sets the global opacity of this image. Any alpha values in the image will be multipled by this value,
  * `mode`, `foreground` and `background` - By default, mode is `"RGBA"`, so your images will draw in their true colors. If you set it to `"MONO"`, any pixels which are black or have transparency will be drawn in the `background` color and all other pixels of the image will be drawn in the `foreground` color. Both colors must be `Color` objects, and default to `Color.black` and `Color.white`, respectively.
 
 Transforms are applied as follows: Crop to the region, then rotate, then scale/flip.

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -20,9 +20,11 @@ typedef struct {
   VEC dest;
 
   COLOR_MODE mode;
-  // MONO colour palette
+  // MONO color palette
   uint32_t backgroundColor;
   uint32_t foregroundColor;
+  // Tint color value
+  uint32_t tintColor;
 } DRAW_COMMAND;
 
 DRAW_COMMAND DRAW_COMMAND_init(IMAGE* image) {
@@ -42,6 +44,7 @@ DRAW_COMMAND DRAW_COMMAND_init(IMAGE* image) {
   command.mode = COLOR_MODE_RGBA;
   command.backgroundColor = 0xFF000000;
   command.foregroundColor = 0xFFFFFFFF;
+  command.tintColor = 0x00000000;
 
   return command;
 }
@@ -125,6 +128,10 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
           color = ((uint8_t)(alpha * command.opacity) << 24) | (preColor & 0x00FFFFFF);
         }
         ENGINE_pset(engine, x, y, color);
+        // Only apply the tint on visible pixels
+        if (command.tintColor != 0 && color != 0 && (alpha * command.opacity) != 0) {
+          ENGINE_pset(engine, x, y, command.tintColor);
+        }
       }
     }
   }
@@ -191,6 +198,10 @@ DRAW_COMMAND_allocate(WrenVM* vm) {
     wrenGetListElement(vm, 2, 10, 1);
     ASSERT_SLOT_TYPE(vm, 1, NUM, "opacity");
     command->opacity = wrenGetSlotDouble(vm, 1);
+
+    wrenGetListElement(vm, 2, 11, 1);
+    ASSERT_SLOT_TYPE(vm, 1, NUM, "tint color");
+    command->tintColor = wrenGetSlotDouble(vm, 1);
   }
 }
 

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -11,6 +11,7 @@ typedef struct {
   IMAGE* image;
   VEC scale;
   double angle;
+  double opacity;
 
   int32_t srcW;
   int32_t srcH;
@@ -35,6 +36,8 @@ DRAW_COMMAND DRAW_COMMAND_init(IMAGE* image) {
 
   command.angle = 0;
   command.scale = (VEC) { 1, 1 };
+
+  command.opacity = 1;
 
   command.mode = COLOR_MODE_RGBA;
   command.backgroundColor = 0xFF000000;
@@ -109,14 +112,17 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
           v = swap;
         }
 
-        uint32_t color = *(pixel + (v * image->width + u));
+        uint32_t preColor = *(pixel + (v * image->width + u));
+        uint32_t color = preColor;
+        uint8_t alpha = (0xFF000000 & color) >> 24;
         if (command.mode == COLOR_MODE_MONO) {
-          uint8_t alpha = (0xFF000000 & color) >> 24;
           if (alpha < 0xFF || (color & 0x00FFFFFF) == 0) {
             color = command.backgroundColor;
           } else {
             color = command.foregroundColor;
           }
+        } else {
+          color = ((uint8_t)(alpha * command.opacity) << 24) | (preColor & 0x00FFFFFF);
         }
         ENGINE_pset(engine, x, y, color);
       }
@@ -181,6 +187,10 @@ DRAW_COMMAND_allocate(WrenVM* vm) {
     wrenGetListElement(vm, 2, 9, 1);
     ASSERT_SLOT_TYPE(vm, 1, NUM, "background color");
     command->backgroundColor = wrenGetSlotDouble(vm, 1);
+
+    wrenGetListElement(vm, 2, 10, 1);
+    ASSERT_SLOT_TYPE(vm, 1, NUM, "opacity");
+    command->opacity = wrenGetSlotDouble(vm, 1);
   }
 }
 

--- a/src/modules/image.wren
+++ b/src/modules/image.wren
@@ -16,7 +16,8 @@ foreign class DrawCommand is Drawable {
       map["srcH"] || image.height,
       map["mode"] || "RGBA",
       (map["foreground"] || Color.white).toNum,
-      (map["background"] || Color.black).toNum
+      (map["background"] || Color.black).toNum,
+      map["opacity"] || 1
     ]
     return DrawCommand.new(image, list)
   }

--- a/src/modules/image.wren
+++ b/src/modules/image.wren
@@ -17,7 +17,8 @@ foreign class DrawCommand is Drawable {
       map["mode"] || "RGBA",
       (map["foreground"] || Color.white).toNum,
       (map["background"] || Color.black).toNum,
-      map["opacity"] || 1
+      map["opacity"] || 1,
+      (map["tint"] || Color.none).toNum
     ]
     return DrawCommand.new(image, list)
   }


### PR DESCRIPTION
Allows the `transform` method to set an image's opacity globally, to allow fading-style effects.