### PR TITLE
Hmm... `is` has lower precedence than `!`

### DIFF
--- a/src/modules/math.wren
+++ b/src/modules/math.wren
@@ -1,7 +1,7 @@
 // Import vector for convenience
 class Math {
   static assertNum(n) {
-    if (!n is Num) {
+    if (!(n is Num)) {
       Fiber.abort("%(n) is not of type Num")
     }
   }


### PR DESCRIPTION
And thus the previous expression was equal to `(!n) is Num`, which is obviously incorrect 😄