### PR TITLE
Represent vector using four fields and not one list

### DIFF
--- a/src/modules/vector.wren
+++ b/src/modules/vector.wren
@@ -13,17 +13,20 @@ class Vector {
   }
 
   init_(x, y, z, w) {
-    _values = [x, y, z, w]
+    _x = x
+    _y = y
+    _z = z
+    _w = w
   }
 
-  x { _values[0] }
-  y { _values[1] }
-  z { _values[2] }
-  w { _values[3] }
-  x=(v) { _values[0] = v }
-  y=(v) { _values[1] = v }
-  z=(v) { _values[2] = v }
-  w=(v) { _values[3] = v }
+  x { _x }
+  y { _y }
+  z { _z }
+  w { _w }
+  x=(v) { _x = v }
+  y=(v) { _y = v }
+  z=(v) { _z = v }
+  w=(v) { _w = v }
 
   manhattan {
     return x.abs + y.abs + z.abs + w.abs


### PR DESCRIPTION
It is more performant, which is important when we create a lot of vectors, which is common in games, especially if you remember that every operation on vector creates a new vector.
It is also nicer (IMHO), and would allow us to use short field representation if https://github.com/wren-lang/wren/issues/849 will be accepted.

The reasons it's more performant:
 - Lists have a backing storage, which is storage separately, meaning more memory + more GC + more indirection. All affect performance, and not for good.
 - Lists must do bounds checking every time we access an element. Fields don't.
 - **Edit:** Lists also call methods in order to access the element (`[_]`). We already have a method call for accessing each field, as we access their getters and not directly the fields. We can access the fields, but I afraid that we would need to change that if the above referenced issue will be accepted (because we won't have a way to directly refer the field then). Method call for every property access hurts performance. Sixteen method calls (for each vector (`this` and `other`)) -> for each field (4) -> a getter -> a list subscript) for operations like addition is even worse. We can reduce them to half.