### PR TITLE
Update Wren to 0.4.0-pre

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -68,10 +68,7 @@ internal WrenForeignMethodFn VM_bind_foreign_method(
 
 internal WrenLoadModuleResult
 VM_load_module(WrenVM* vm, const char* name) {
-  WrenLoadModuleResult result;
-  result.source = NULL;
-  result.onComplete = NULL;
-  result.userData = NULL;
+  WrenLoadModuleResult result = { 0 };
 
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
   MAP moduleMap = engine->moduleMap;

--- a/src/vm.c
+++ b/src/vm.c
@@ -66,7 +66,13 @@ internal WrenForeignMethodFn VM_bind_foreign_method(
   return MAP_getFunction(&moduleMap, module, fullName);
 }
 
-internal char* VM_load_module(WrenVM* vm, const char* name) {
+internal WrenLoadModuleResult
+VM_load_module(WrenVM* vm, const char* name) {
+  WrenLoadModuleResult result;
+  result.source = NULL;
+  result.onComplete = NULL;
+  result.userData = NULL;
+
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
   MAP moduleMap = engine->moduleMap;
 
@@ -80,7 +86,7 @@ internal char* VM_load_module(WrenVM* vm, const char* name) {
     if (DEBUG_MODE) {
       ENGINE_printLog(engine, "wren\n", name);
     }
-    return NULL;
+    return result;
   }
 #endif
 #if WREN_OPT_RANDOM
@@ -88,7 +94,7 @@ internal char* VM_load_module(WrenVM* vm, const char* name) {
     if (DEBUG_MODE) {
       ENGINE_printLog(engine, "wren\n", name);
     }
-    return NULL;
+    return result;
   }
 #endif
 
@@ -99,7 +105,8 @@ internal char* VM_load_module(WrenVM* vm, const char* name) {
     if (DEBUG_MODE) {
       ENGINE_printLog(engine, "dome\n", name);
     }
-    return module;
+    result.source = module;
+    return result;
   }
 
   // Otherwise, search on filesystem
@@ -117,7 +124,8 @@ internal char* VM_load_module(WrenVM* vm, const char* name) {
   char* file = ENGINE_readFile(engine, path, NULL);
 
   free(path);
-  return file;
+  result.source = file;
+  return result;
 }
 
 // Debug output for VM


### PR DESCRIPTION
We are using the Wren 0.4.0 pre-release tag because there is not expected to be any code changes between it and the official release tag. See the change list here: https://github.com/wren-lang/wren/releases/tag/0.4.0-pre

It also brings a number of bug-fixes which will improve the overall stability and robustness of DOME, as well as a few API improvements and some expanded functionality which can be made use of by all games moving forward.