### PR TITLE
Normalising the module paths so that we don't do unnecessary loading …

### DIFF
--- a/include/mkdirp/mkdirp.c
+++ b/include/mkdirp/mkdirp.c
@@ -36,7 +36,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define PATH_SEPARATOR   '/'
 #endif
 
-char *
+const char*
 path_normalize(const char *path) {
   if (!path) return NULL;
 

--- a/include/mkdirp/mkdirp.h
+++ b/include/mkdirp/mkdirp.h
@@ -34,5 +34,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 int mkdirp(const char *, mode_t );
+const char* path_normalize(const char* path);
 
 #endif

--- a/src/vm.c
+++ b/src/vm.c
@@ -119,8 +119,8 @@ VM_load_module(WrenVM* vm, const char* name) {
 
   // This pointer becomes owned by the WrenVM and freed later.
   char* file = ENGINE_readFile(engine, path, NULL);
-
   free(path);
+
   result.source = file;
   return result;
 }
@@ -174,6 +174,17 @@ internal void VM_error(WrenVM* vm, WrenErrorType type, const char* module,
   engine->debug.errorBufLen += len;
 }
 
+internal const char*
+VM_resolve_module_name(WrenVM* vm, const char* importer, const char* name) {
+  char* localName = name;
+  if (strlen(name) > 1) {
+    while (localName[0] == '.' && localName[1] == '/') {
+      localName = localName + 2;
+    }
+  }
+  return path_normalize(localName);
+}
+
 internal WrenVM* VM_create(ENGINE* engine) {
   WrenConfiguration config;
   wrenInitConfiguration(&config);
@@ -181,6 +192,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   config.errorFn = VM_error;
   config.bindForeignMethodFn = VM_bind_foreign_method;
   config.bindForeignClassFn = VM_bind_foreign_class;
+  config.resolveModuleFn = VM_resolve_module_name;
   config.loadModuleFn = VM_load_module;
 
   WrenVM* vm = wrenNewVM(&config);


### PR DESCRIPTION
It turns out that because we weren't making use of the VM resolveModuleFn feature, switching between `./moduleName` and `moduleName` in your imports would result in incompatible duplicate imports.

This would result in higher memory consumption, decreased startup speed and language semantics failing because you'd have two occurrences of the same class, being considered separately by the VM.

We leverage the path-normalize method in mkdirp to resolve this in advance.