### PR TITLE
Audio Engine re-architecting (pt1) + resampling

### DIFF
--- a/docs/modules/audio.md
+++ b/docs/modules/audio.md
@@ -15,7 +15,7 @@ It contains the following classes:
 
 DOME supports playback of audio files in OGG and WAV formats. It will convert all files to its native sample rate of 44.1kHz (CD quality audio), but the re-sampling algorithm used is naive and may introduce audio artifacts. It is recommended that you produce your audio with a 44.1kHz sample-rate, for the best quality audio.
 
-An audio file is loaded from disk into memory using the `load` function, and remains in memory until you call `unload(_)` or `unloadAll()`, or when DOME closes.
+An audio file is loaded from disk into memory using the `load` function, and remains in memory until you call `unload(_)` or `unloadAll()`, or when DOME closes. If the audio needs to be resampled, this may take some time and block the main thread.
 
 When an audio file is about to be played, DOME allocates it an "audio channel", which handles the settings for volume, looping and panning.
 Once the audio is stopped or finishes playing, that channel is no longer usable, and a new one will need to be acquired.

--- a/examples/audio/main.wren
+++ b/examples/audio/main.wren
@@ -1,0 +1,19 @@
+import "graphics" for Canvas, Color
+import "audio" for AudioEngine
+import "input" for Keyboard
+class Game {
+    static init() {
+      AudioEngine.load("music", "../spaceshooter/res/around-the-corner.ogg")
+      AudioEngine.load("sfx", "../spaceshooter/res/Laser_Shoot.wav")
+      AudioEngine.play("music")
+
+    }
+    static update() {
+      if (Keyboard["space"].justPressed) {
+        AudioEngine.play("sfx")
+      }
+    }
+    static draw(dt) {
+      Canvas.print("DOME Installed Successfully.", 10, 10, Color.white)
+    }
+}

--- a/examples/audio/main.wren
+++ b/examples/audio/main.wren
@@ -18,8 +18,17 @@ class Game {
       if (Keyboard["backspace"].justPressed) {
         __channel.stop()
       }
+      if (Keyboard["left"].justPressed) {
+        __channel.pan = __channel.pan - 0.05
+      }
+      if (Keyboard["right"].justPressed) {
+        __channel.pan = __channel.pan + 0.05
+      }
     }
     static draw(dt) {
-      Canvas.print("DOME Installed Successfully.", 10, 10, Color.white)
+      Canvas.cls()
+      Canvas.print(__channel == null ? "Nothing Playing" : "Music Playing", 10, 10, Color.white)
+      Canvas.print(__channel == null ? "" : "Volume %(__channel.volume)", 10, 18, Color.white)
+      Canvas.print(__channel == null ? "" : "Pan %(__channel.pan)", 10, 26, Color.white)
     }
 }

--- a/examples/audio/main.wren
+++ b/examples/audio/main.wren
@@ -21,6 +21,10 @@ class Game {
       if (Keyboard["0"].justPressed) {
         AudioEngine.stopAllChannels()
       }
+      if (Keyboard["-"].justPressed) {
+        AudioEngine.unload("music")
+        AudioEngine.unload("sfx")
+      }
       if (Keyboard["left"].justPressed) {
         __channel.pan = __channel.pan - 0.05
       }

--- a/examples/audio/main.wren
+++ b/examples/audio/main.wren
@@ -5,12 +5,18 @@ class Game {
     static init() {
       AudioEngine.load("music", "../spaceshooter/res/around-the-corner.ogg")
       AudioEngine.load("sfx", "../spaceshooter/res/Laser_Shoot.wav")
-      AudioEngine.play("music")
+      __channel = AudioEngine.play("music")
 
     }
     static update() {
-      if (Keyboard["space"].justPressed) {
+      if (Keyboard["return"].justPressed) {
         AudioEngine.play("sfx")
+      }
+      if (Keyboard["space"].justPressed) {
+        __channel = AudioEngine.play("music")
+      }
+      if (Keyboard["backspace"].justPressed) {
+        __channel.stop()
       }
     }
     static draw(dt) {

--- a/examples/audio/main.wren
+++ b/examples/audio/main.wren
@@ -26,10 +26,22 @@ class Game {
         AudioEngine.unload("sfx")
       }
       if (Keyboard["left"].justPressed) {
-        __channel.pan = __channel.pan - 0.05
+        __channel.pan = __channel.pan - 0.01
       }
       if (Keyboard["right"].justPressed) {
-        __channel.pan = __channel.pan + 0.05
+        __channel.pan = __channel.pan + 0.01
+      }
+      if (Keyboard["down"].justPressed) {
+        __channel.volume = __channel.volume - 0.01
+      }
+      if (Keyboard["up"].justPressed) {
+        __channel.volume = __channel.volume + 0.01
+      }
+      if (__channel.pan.abs < 0.009) {
+        __channel.pan = 0
+      }
+      if (__channel.volume.abs < 0.009) {
+        __channel.volume = 0
       }
     }
     static draw(dt) {

--- a/examples/audio/main.wren
+++ b/examples/audio/main.wren
@@ -18,6 +18,9 @@ class Game {
       if (Keyboard["backspace"].justPressed) {
         __channel.stop()
       }
+      if (Keyboard["0"].justPressed) {
+        AudioEngine.stopAllChannels()
+      }
       if (Keyboard["left"].justPressed) {
         __channel.pan = __channel.pan - 0.05
       }

--- a/src/main.c
+++ b/src/main.c
@@ -61,7 +61,6 @@
 
 // Used in the io variable, but we need to catch it here
 global_variable WrenHandle* bufferClass = NULL;
-global_variable WrenHandle* audioEngineClass = NULL;
 global_variable WrenHandle* keyboardClass = NULL;
 global_variable WrenHandle* mouseClass = NULL;
 global_variable WrenHandle* gamepadClass = NULL;
@@ -282,20 +281,7 @@ LOOP_update(LOOP_STATE* state) {
     return EXIT_FAILURE;
   }
   // updateAudio()
-  if (audioEngineClass != NULL) {
-    AUDIO_ENGINE_update(state->vm);
-    /*
-    wrenEnsureSlots(state->vm, 3);
-    wrenSetSlotHandle(state->vm, 0, audioEngineClass);
-    AUDIO_ENGINE_lock(state->engine->audioEngine);
-    interpreterResult = wrenCall(state->vm, state->updateMethod);
-    AUDIO_ENGINE_unlock(state->engine->audioEngine);
-
-    if (interpreterResult != WREN_RESULT_SUCCESS) {
-      return EXIT_FAILURE;
-    }
-    */
-  }
+  AUDIO_ENGINE_update(state->vm);
   return EXIT_SUCCESS;
 }
 
@@ -690,10 +676,6 @@ vm_cleanup:
 
   if (bufferClass != NULL) {
     wrenReleaseHandle(vm, bufferClass);
-  }
-
-  if (audioEngineClass != NULL) {
-    wrenReleaseHandle(vm, audioEngineClass);
   }
 
   INPUT_release(vm);

--- a/src/main.c
+++ b/src/main.c
@@ -699,6 +699,7 @@ cleanup:
   ENGINE_reportError(&engine);
   BASEPATH_free();
   AUDIO_ENGINE_halt(engine.audioEngine);
+  AUDIO_ENGINE_releaseHandles(engine.audioEngine, vm);
   VM_free(vm);
   result = engine.exit_status;
   ENGINE_free(&engine);

--- a/src/main.c
+++ b/src/main.c
@@ -694,12 +694,13 @@ vm_cleanup:
 
   INPUT_release(vm);
 
+  AUDIO_ENGINE_halt(engine.audioEngine);
+  AUDIO_ENGINE_releaseHandles(engine.audioEngine, vm);
+
 cleanup:
   // Free resources
   ENGINE_reportError(&engine);
   BASEPATH_free();
-  AUDIO_ENGINE_halt(engine.audioEngine);
-  AUDIO_ENGINE_releaseHandles(engine.audioEngine, vm);
   VM_free(vm);
   result = engine.exit_status;
   ENGINE_free(&engine);

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,7 @@
 #include <sys/stat.h>
 #include <string.h>
 #include <libgen.h>
+#include <time.h>
 #include <math.h>
 #ifndef M_PI
   #define M_PI 3.14159265358979323846

--- a/src/main.c
+++ b/src/main.c
@@ -557,12 +557,13 @@ int main(int argc, char* args[])
 
   wrenSetSlotHandle(vm, 0, loop.gameClass);
   interpreterResult = wrenCall(vm, initMethod);
-  wrenReleaseHandle(vm, initMethod);
-  initMethod = NULL;
   if (interpreterResult != WREN_RESULT_SUCCESS) {
     result = EXIT_FAILURE;
     goto vm_cleanup;
   }
+  // Release this handle if it finished successfully
+  wrenReleaseHandle(vm, initMethod);
+  initMethod = NULL;
   engine.initialized = true;
 
   SDL_SetWindowPosition(engine.window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
@@ -678,6 +679,9 @@ vm_cleanup:
     }
   }
 
+  // Free resources
+  ENGINE_reportError(&engine);
+
   if (initMethod != NULL) {
     wrenReleaseHandle(vm, initMethod);
   }
@@ -698,8 +702,6 @@ vm_cleanup:
   AUDIO_ENGINE_releaseHandles(engine.audioEngine, vm);
 
 cleanup:
-  // Free resources
-  ENGINE_reportError(&engine);
   BASEPATH_free();
   VM_free(vm);
   result = engine.exit_status;

--- a/src/main.c
+++ b/src/main.c
@@ -283,14 +283,18 @@ LOOP_update(LOOP_STATE* state) {
   }
   // updateAudio()
   if (audioEngineClass != NULL) {
+    AUDIO_ENGINE_update(state->vm);
+    /*
     wrenEnsureSlots(state->vm, 3);
     wrenSetSlotHandle(state->vm, 0, audioEngineClass);
     AUDIO_ENGINE_lock(state->engine->audioEngine);
     interpreterResult = wrenCall(state->vm, state->updateMethod);
     AUDIO_ENGINE_unlock(state->engine->audioEngine);
+
     if (interpreterResult != WREN_RESULT_SUCCESS) {
       return EXIT_FAILURE;
     }
+    */
   }
   return EXIT_SUCCESS;
 }
@@ -546,7 +550,7 @@ int main(int argc, char* args[])
   loop.gameClass = wrenGetSlotHandle(vm, 0);
   loop.updateMethod = wrenMakeCallHandle(vm, "update()");
   loop.drawMethod = wrenMakeCallHandle(vm, "draw(_)");
-  
+
   SDL_SetRenderDrawColor(engine.renderer, 0x00, 0x00, 0x00, 0xFF);
 
   // Initiate game loop

--- a/src/math.c
+++ b/src/math.c
@@ -42,8 +42,8 @@ VEC VEC_perp(VEC v) {
   return result;
 }
 
-
-float lerp(float a, float b, float f) {
+internal float
+lerp(float a, float b, float f) {
   return (a * (1.0 - f)) + (b * f);
 }
 

--- a/src/math.c
+++ b/src/math.c
@@ -43,6 +43,9 @@ VEC VEC_perp(VEC v) {
 }
 
 
+float lerp(float a, float b, float f) {
+  return (a * (1.0 - f)) + (b * f);
+}
 
 
 int64_t max(int64_t n1, int64_t n2) {

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -192,17 +192,18 @@ AUDIO_CHANNEL_mix(void* gChannel, float* stream, size_t totalSamples) {
     *(writeCursor++) += *(readCursor++) * sin(pan) * currentVolume;
 
     channel->current.position++;
-    if (channel->current.loop && channel->current.position >= length) {
-      channel->current.position = 0;
-      readCursor = startReadCursor;
-    }
-    if (!channel->core.enabled) {
-      break;
+    if (channel->current.position >= length) {
+      if (channel->current.loop) {
+        channel->current.position = 0;
+        readCursor = startReadCursor;
+      } else {
+        break;
+      }
     }
   }
   channel->actualVolume = channel->current.volume;
   channel->actualPan = channel->current.pan;
-  channel->core.enabled = channel->core.enabled && (channel->current.loop || channel->current.position < length);
+  channel->core.enabled = (channel->current.loop || channel->current.position < length);
 }
 
 // audio callback function
@@ -460,7 +461,6 @@ internal void
 AUDIO_ENGINE_unlock(AUDIO_ENGINE* engine) {
   SDL_UnlockAudioDevice(engine->deviceId);
 }
-
 
 internal void
 AUDIO_ENGINE_pushChannel(AUDIO_ENGINE* engine, GENERIC_CHANNEL* channel) {

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -82,7 +82,7 @@ typedef struct AUDIO_ENGINE_t {
 } AUDIO_ENGINE;
 
 const uint16_t channels = 2;
-const uint16_t bytesPerSample = 4; // 4-byte float * 2 channels;
+const uint16_t bytesPerSample = 8; // 4-byte float * 2 channels;
 
 internal void
 AUDIO_CHANNEL_finish(WrenVM* vm, void* gChannel) {
@@ -129,7 +129,6 @@ AUDIO_CHANNEL_update(WrenVM* vm, void* gChannel) {
       }
       // We assume data is loaded by now.
       channel->core.state = CHANNEL_PLAYING;
-      channel->core.enabled = true;
       AUDIO_CHANNEL_commit(channel);
       break;
     case CHANNEL_LOADING:
@@ -576,6 +575,12 @@ AUDIO_ENGINE_stop(AUDIO_ENGINE* engine, uintmax_t id) {
 }
 
 internal void
+AUDIO_CHANNEL_stop(WrenVM* vm) {
+  AUDIO_CHANNEL* channel = (AUDIO_CHANNEL*)wrenGetSlotForeign(vm, 0);
+  channel->core.stopRequested = true;
+}
+
+internal void
 AUDIO_ENGINE_wrenStopAll(WrenVM* vm) {
   ENGINE* engine = wrenGetUserData(vm);
   AUDIO_ENGINE* audioEngine = engine->audioEngine;
@@ -699,17 +704,6 @@ AUDIO_CHANNEL_getPosition(WrenVM* vm) {
   AUDIO_CHANNEL* channel = (AUDIO_CHANNEL*)wrenGetSlotForeign(vm, 0);
   wrenEnsureSlots(vm, 1);
   wrenSetSlotDouble(vm, 0, channel->new.position);
-}
-
-internal void
-AUDIO_CHANNEL_setEnabled(WrenVM* vm) {
-  AUDIO_CHANNEL* channel = (AUDIO_CHANNEL*)wrenGetSlotForeign(vm, 0);
-  ASSERT_SLOT_TYPE(vm, 1, BOOL, "enabled");
-  if (channel->core.enabled) {
-    channel->core.stopRequested = !wrenGetSlotBool(vm, 1);
-  } else {
-    channel->core.enabled = wrenGetSlotBool(vm, 1);
-  }
 }
 
 internal void

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -96,16 +96,21 @@ void AUDIO_ENGINE_mix(void*  userdata,
     float pan = (channel->pan + 1) * M_PI / 4.0; // Channel pan is [-1,1] real pan needs to be [0,1]
     float* startReadCursor = (float*)(audio->buffer) + channel->position * channels;
     float* readCursor = startReadCursor;
+    float* writeCursor = (float*)(stream);
     for (int i = 0; i < samplesToWrite; i++) {
-      writeCursor[i*2] += readCursor[0] * cos(pan) * volume;
-      writeCursor[i*2+1] += readCursor[1] * sin(pan) * volume;
+      writeCursor[0] += readCursor[0] * cos(pan) * volume;
+      writeCursor[1] += readCursor[1] * sin(pan) * volume;
       readCursor += channels;
+      writeCursor += channels;
       channel->position++;
       if (channel->loop && channel->position >= audio->length) {
         channel->position = 0;
         readCursor = startReadCursor;
       }
       channel->enabled = channel->enabled && channel->position < audio->length;
+      if (!channel->enabled) {
+        break;
+      }
     }
   }
   for (int i = 0; i < samplesToWrite; i++) {

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -626,10 +626,7 @@ AUDIO_CHANNEL_allocate(WrenVM* vm) {
   AUDIO_CHANNEL* channel = (AUDIO_CHANNEL*)wrenSetSlotNewForeign(vm, 0, 0, sizeof(AUDIO_CHANNEL));
   ASSERT_SLOT_TYPE(vm, 1, STRING, "sound id");
   const char* soundId = wrenGetSlotString(vm, 1);
-  size_t len = strlen(soundId);
-  channel->core.soundId = malloc((1 + len) * sizeof(char));
-  strcpy(channel->core.soundId, soundId);
-  channel->core.soundId[len] = '\0';
+  channel->core.soundId = strdup(soundId);
 
   struct AUDIO_CHANNEL_PROPS props = {0, 0, 0, 0, 0};
   channel->current = channel->new = props;

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -113,16 +113,14 @@ void AUDIO_ENGINE_mix(void*  userdata,
         readCursor = startReadCursor;
       }
     }
-    channel->enabled = channel->position < length;
+    channel->enabled = channel->loop || channel->position < length;
   }
 
   // Mix using tanh
   float* outputCursor = (float*)(stream);
-  for (size_t i = 0; i < totalSamples; i++) {
+  float* endPoint = outputCursor + totalSamples * channels;
+  for (; outputCursor < endPoint; outputCursor++) {
     *outputCursor += tanh(*outputCursor);
-    outputCursor++;
-    *outputCursor += tanh(*outputCursor);
-    outputCursor++;
   }
 }
 

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -1,5 +1,5 @@
 #define AUDIO_CHANNEL_START 0
-#define SAMPLE_RATE 48000
+#define SAMPLE_RATE 44100
 
 typedef enum {
   CHANNEL_INVALID,

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -82,7 +82,7 @@ typedef struct AUDIO_ENGINE_t {
 } AUDIO_ENGINE;
 
 global_variable const uint16_t channels = 2;
-global_variable const uint16_t bytesPerSample = 4 * channels; // 4-byte float * 2 channels;
+global_variable const uint16_t bytesPerSample = 4 * 2; // 4-byte float * 2 channels;
 
 internal void
 AUDIO_CHANNEL_finish(WrenVM* vm, void* gChannel) {

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -411,7 +411,7 @@ internal void
 AUDIO_ENGINE_push(WrenVM* vm) {
   ENGINE* engine = wrenGetUserData(vm);
   AUDIO_ENGINE* data = engine->audioEngine;
-  // assert
+
   GENERIC_CHANNEL* channel = wrenGetSlotForeign(vm, 1);
   channel->handle = wrenGetSlotHandle(vm, 1);
   channel->enabled = true;
@@ -420,13 +420,10 @@ AUDIO_ENGINE_push(WrenVM* vm) {
 
 internal void
 AUDIO_ENGINE_update(WrenVM* vm) {
-  // We need additional slots to parse a list
-  // wrenEnsureSlots(vm, 3);
   ENGINE* engine = wrenGetUserData(vm);
   AUDIO_ENGINE* data = engine->audioEngine;
   CHANNEL_LIST* pending = data->pending;
   CHANNEL_LIST* playing = data->playing;
-
 
   // Copy enabled channels into pending
   size_t waitCount = pending->count;
@@ -498,6 +495,17 @@ AUDIO_ENGINE_stopAll(AUDIO_ENGINE* engine) {
 }
 
 internal void
+AUDIO_ENGINE_stop(AUDIO_ENGINE* engine, uintmax_t id) {
+  CHANNEL_LIST* playing = engine->playing;
+  for (size_t i = 0; i < playing->count; i++) {
+    GENERIC_CHANNEL* channel = (GENERIC_CHANNEL*)playing->channels[i];
+    if (channel->id == id) {
+      channel->stopRequested = true;
+    }
+  }
+}
+
+internal void
 AUDIO_ENGINE_wrenStopAll(WrenVM* vm) {
   ENGINE* engine = wrenGetUserData(vm);
   AUDIO_ENGINE* audioEngine = engine->audioEngine;
@@ -554,7 +562,7 @@ AUDIO_CHANNEL_allocate(WrenVM* vm) {
 
   struct AUDIO_CHANNEL_PROPS props = {0, 0, 0, 0, 0};
   channel->current = channel->new = props;
-  channel->actualVolume = 1.0f;
+  channel->actualVolume = 0.0f;
 
   channel->core.state = CHANNEL_INITIALIZE;
   channel->core.enabled = true;

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -570,7 +570,7 @@ AUDIO_CHANNEL_setAudio(WrenVM* vm) {
   if (channel->core.state == CHANNEL_INITIALIZE) {
     ASSERT_SLOT_TYPE(vm, 1, FOREIGN, "audio");
     channel->audio = (AUDIO_DATA*)wrenGetSlotForeign(vm, 1);
-    channel->audioHandle = wrenGetSlotHandle(vm, 0);
+    channel->audioHandle = wrenGetSlotHandle(vm, 1);
   } else {
     VM_ABORT(vm, "Cannot change audio in channel once initialized");
   }

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -54,7 +54,7 @@ typedef struct AUDIO_ENGINE_t {
 } AUDIO_ENGINE;
 
 const uint16_t channels = 2;
-const uint16_t bytesPerSample = 2 * 2 /* channels */;
+const uint16_t bytesPerSample = sizeof(float) * 2 /* channels */;
 
 internal void
 AUDIO_ENGINE_capture(WrenVM* vm) {

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -131,15 +131,19 @@ void AUDIO_ENGINE_mix(void*  userdata,
       continue;
     }
     totalEnabled++;
-    size_t requestSize = min(bufferSampleSize, totalSamples);
-    SDL_memset(scratchBuffer, 0, requestSize * sizeof(float) * channels);
-    channel->callback(channel, scratchBuffer, requestSize);
-
+    size_t requestServed = 0;
     float* writeCursor = (float*)(stream);
-    float* copyCursor = scratchBuffer;
-    float* endPoint = copyCursor + requestSize * channels;
-    for (; copyCursor < endPoint; copyCursor++) {
-      *(writeCursor++) += *copyCursor;
+
+    while (requestServed < totalSamples) {
+      SDL_memset(scratchBuffer, 0, bufferSampleSize * sizeof(float) * channels);
+      size_t requestSize = min(bufferSampleSize, totalSamples - requestServed);
+      channel->callback(channel, scratchBuffer, requestSize);
+      requestServed += requestSize;
+      float* copyCursor = scratchBuffer;
+      float* endPoint = copyCursor + bufferSampleSize * channels;
+      for (; copyCursor < endPoint; copyCursor++) {
+        *(writeCursor++) += *copyCursor;
+      }
     }
   }
 

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -98,10 +98,12 @@ void AUDIO_ENGINE_mix(void*  userdata,
     float* writeCursor = (float*)(stream);
     size_t length = audio->length;
     for (size_t i = 0; i < totalSamples; i++) {
-      writeCursor[0] += readCursor[0] * cos(pan) * volume;
-      writeCursor[1] += readCursor[1] * sin(pan) * volume;
-      readCursor += channels;
-      writeCursor += channels;
+      *writeCursor += *readCursor * cos(pan) * volume;
+      writeCursor += 1;
+      readCursor += 1;
+      *writeCursor += *readCursor * sin(pan) * volume;
+      readCursor += 1;
+      writeCursor += 1;
       channel->position++;
       if (channel->loop && channel->position >= length) {
         channel->position = 0;
@@ -118,8 +120,10 @@ void AUDIO_ENGINE_mix(void*  userdata,
   // Mix using tanh
   float* outputCursor = (float*)(stream);
   for (size_t i = 0; i < totalSamples; i++) {
-    outputCursor[i*2] += tanh(outputCursor[i*2]);
-    outputCursor[i*2+1] += tanh(outputCursor[i*2+1]);
+    *outputCursor += tanh(*outputCursor);
+    outputCursor++;
+    *outputCursor += tanh(*outputCursor);
+    outputCursor++;
   }
 }
 

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -224,7 +224,6 @@ void AUDIO_ENGINE_mix(void*  userdata,
   SDL_memset(stream, 0, outputBufferSize);
   CHANNEL_LIST* playing = audioEngine->playing;
   size_t channelCount = playing->count;
-  size_t totalEnabled = 0;
 
   float* scratchBuffer = audioEngine->scratchBuffer;
   size_t bufferSampleSize = audioEngine->scratchBufferSize;
@@ -234,7 +233,6 @@ void AUDIO_ENGINE_mix(void*  userdata,
     if (channel == NULL) {
       continue;
     }
-    totalEnabled++;
     size_t requestServed = 0;
     float* writeCursor = (float*)(stream);
 

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -72,6 +72,7 @@ typedef struct AUDIO_ENGINE_t {
   size_t scratchBufferSize;
   CHANNEL_LIST* pending;
   CHANNEL_LIST* playing;
+  uintmax_t nextId;
 } AUDIO_ENGINE;
 
 const uint16_t channels = 2;
@@ -558,7 +559,7 @@ internal void
 AUDIO_CHANNEL_getPosition(WrenVM* vm) {
   AUDIO_CHANNEL* channel = (AUDIO_CHANNEL*)wrenGetSlotForeign(vm, 0);
   wrenEnsureSlots(vm, 1);
-  wrenSetSlotDouble(vm, 0, channel->current.position);
+  wrenSetSlotDouble(vm, 0, channel->new.position);
 }
 
 internal void
@@ -608,7 +609,7 @@ internal void
 AUDIO_CHANNEL_getVolume(WrenVM* vm) {
   AUDIO_CHANNEL* channel = (AUDIO_CHANNEL*)wrenGetSlotForeign(vm, 0);
   wrenEnsureSlots(vm, 1);
-  wrenSetSlotDouble(vm, 0, channel->current.volume);
+  wrenSetSlotDouble(vm, 0, channel->new.volume);
 }
 
 internal void
@@ -622,7 +623,7 @@ internal void
 AUDIO_CHANNEL_getPan(WrenVM* vm) {
   AUDIO_CHANNEL* channel = (AUDIO_CHANNEL*)wrenGetSlotForeign(vm, 0);
   wrenEnsureSlots(vm, 1);
-  wrenSetSlotDouble(vm, 0, channel->current.pan);
+  wrenSetSlotDouble(vm, 0, channel->new.pan);
 }
 
 internal void

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -81,8 +81,8 @@ typedef struct AUDIO_ENGINE_t {
   uintmax_t nextId;
 } AUDIO_ENGINE;
 
-const uint16_t channels = 2;
-const uint16_t bytesPerSample = 4 * channels; // 4-byte float * 2 channels;
+global_variable const uint16_t channels = 2;
+global_variable const uint16_t bytesPerSample = 4 * channels; // 4-byte float * 2 channels;
 
 internal void
 AUDIO_CHANNEL_finish(WrenVM* vm, void* gChannel) {

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -1,5 +1,5 @@
 #define AUDIO_CHANNEL_START 0
-#define SAMPLE_RATE 44100
+#define SAMPLE_RATE 48000
 
 typedef enum {
   CHANNEL_INVALID,
@@ -57,6 +57,7 @@ typedef struct {
   struct AUDIO_CHANNEL_PROPS new;
   float actualVolume;
   float actualPan;
+  bool fade;
 
   AUDIO_DATA* audio;
   WrenHandle* audioHandle;
@@ -143,7 +144,11 @@ AUDIO_CHANNEL_update(WrenVM* vm, void* gChannel) {
       }
       break;
     case CHANNEL_STOPPING:
-      channel->new.volume -= 0.1;
+      if (channel->fade) {
+        channel->new.volume -= 0.1;
+      } else {
+        channel->new.volume = 0;
+      }
       AUDIO_CHANNEL_commit(channel);
       if (channel->new.volume <= 0) {
         channel->new.volume = 0;

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -82,7 +82,8 @@ typedef struct AUDIO_ENGINE_t {
 } AUDIO_ENGINE;
 
 const uint16_t channels = 2;
-const uint16_t bytesPerSample = sizeof(float) * channels;
+const uint16_t bytesPerChannel = sizeof(float);
+const uint16_t bytesPerSample = bytesPerChannel * channels;
 
 internal void
 AUDIO_CHANNEL_finish(WrenVM* vm, void* gChannel) {
@@ -370,8 +371,7 @@ resample(float* data, size_t srcLength, uint64_t srcFrequency, uint64_t targetFr
   sampleCursor = tempData;
   writeCursor = destData;
 
-  size_t i, j;
-  for(j = i = 0; i < tempSampleCount; i += M) {
+  for(size_t i = 0; i < tempSampleCount; i += M) {
     *(writeCursor++) = sampleCursor[i*2];
     *(writeCursor++) = sampleCursor[i*2+1];
   }

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -291,7 +291,7 @@ AUDIO_allocate(WrenVM* vm) {
 
     data->spec.channels = channelsInFile;
     data->spec.freq = freq;
-    data->spec.format = AUDIO_F32LSB; // AUDIO_S16LSB;
+    data->spec.format = AUDIO_F32LSB;
   } else {
     VM_ABORT(vm, "Audio file was of an incompatible format");
     return;
@@ -341,12 +341,10 @@ resample(float* data, size_t srcLength, uint64_t srcFrequency, uint64_t targetFr
   size_t sampleCount = srcLength;
 
   size_t tempSampleCount = sampleCount * L;
-  size_t tempLength = tempSampleCount * channels;
   float* tempData = calloc(tempSampleCount, bytesPerSample);
   if (tempData == NULL) {
     return NULL;
   }
-
 
   size_t destSampleCount = ceil(tempSampleCount / M) + 1;
   *destLength = destSampleCount;

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -82,8 +82,7 @@ typedef struct AUDIO_ENGINE_t {
 } AUDIO_ENGINE;
 
 const uint16_t channels = 2;
-const uint16_t bytesPerChannel = sizeof(float);
-const uint16_t bytesPerSample = bytesPerChannel * channels;
+const uint16_t bytesPerSample = 4; // 4-byte float * 2 channels;
 
 internal void
 AUDIO_CHANNEL_finish(WrenVM* vm, void* gChannel) {

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -127,14 +127,14 @@ void AUDIO_ENGINE_mix(void*  userdata,
 
   for (size_t c = 0; c < channelCount; c++) {
     GENERIC_CHANNEL* channel = (GENERIC_CHANNEL*)(channelList->channels[c]);
-    if (channel == NULL || !channel->enabled) {
+    if (channel == NULL) {
       continue;
     }
     totalEnabled++;
     size_t requestServed = 0;
     float* writeCursor = (float*)(stream);
 
-    while (requestServed < totalSamples) {
+    while (channel->enabled && requestServed < totalSamples) {
       SDL_memset(scratchBuffer, 0, bufferSampleSize * sizeof(float) * channels);
       size_t requestSize = min(bufferSampleSize, totalSamples - requestServed);
       channel->callback(channel, scratchBuffer, requestSize);

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -56,10 +56,6 @@ typedef struct AUDIO_ENGINE_t {
 const uint16_t channels = 2;
 const uint16_t bytesPerSample = 2 * 2 /* channels */;
 
-// audio callback function
-// Allows SDL to "pull" data into the output buffer
-// on a seperate thread. We need to be pretty efficient
-// here as it holds a lock.
 internal void
 AUDIO_ENGINE_capture(WrenVM* vm) {
   if (audioEngineClass == NULL) {
@@ -68,6 +64,10 @@ AUDIO_ENGINE_capture(WrenVM* vm) {
   }
 }
 
+// audio callback function
+// Allows SDL to "pull" data into the output buffer
+// on a seperate thread. We need to be pretty efficient
+// here as it holds a lock.
 void AUDIO_ENGINE_mix(void*  userdata,
     Uint8* stream,
     int    outputBufferSize) {

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -245,15 +245,6 @@ void AUDIO_ENGINE_mix(void*  userdata,
       }
     }
   }
-
-  // Mix using tanh
-  float* readCursor = (float*)(stream);
-  float* outputCursor = (float*)(stream);
-  float* endPoint = readCursor + totalSamples * channels;
-  for (; readCursor < endPoint; readCursor++) {
-    *(outputCursor) = (float)(tanh(*readCursor));
-    outputCursor++;
-  }
 }
 
 internal float* resample(float* data, size_t srcLength, uint64_t srcFrequency, uint64_t targetFrequency, size_t* destLength);

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -34,7 +34,6 @@ foreign class SystemChannel is AudioChannel {
     // Sensible defaults
     volume = 1
     pan = 0
-    enabled = true
     loop = false
   }
   foreign audio=(value)
@@ -48,7 +47,6 @@ foreign class SystemChannel is AudioChannel {
   foreign state
   foreign state=(value)
 
-  foreign enabled=(enable)
   foreign enabled
 
   foreign loop=(do)
@@ -60,9 +58,7 @@ foreign class SystemChannel is AudioChannel {
   foreign volume=(volume)
   foreign volume
 
-  stop() {
-    enabled = false
-  }
+  foreign stop()
 
   finished { !enabled || state == AudioState.STOPPED }
 }

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -206,6 +206,7 @@ class AudioEngine {
   }
 
   foreign static f_update(list)
+  foreign static f_push(channel)
   static update() {
     var playing = __channels.values.where {|facade|
       if (__unloadQueue.contains(facade.soundId)) {

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -199,6 +199,7 @@ class AudioEngine {
     channel.loop = loop
 
     __nextId = __nextId + 1
+    channel.update_()
     f_push(systemChannel)
     return channel
   }

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -68,7 +68,6 @@ foreign class SystemChannel is AudioChannel {
 class AudioEngine {
   // TODO: Allow device enumeration and selection
   static init() {
-    __unloadQueue = []
     __nameMap = {}
     __files = {}
     __nextId = 0

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -124,7 +124,6 @@ class AudioEngine {
   }
 
   foreign static f_stopAllChannels()
-  foreign static f_update(list)
   foreign static f_push(channel)
 }
 AudioEngine.init()

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -40,6 +40,7 @@ foreign class SystemChannel is AudioChannel {
 
   foreign length
   foreign soundId
+  foreign id
   foreign position
   foreign position=(v)
 
@@ -70,7 +71,6 @@ class AudioEngine {
   static init() {
     __nameMap = {}
     __files = {}
-    __nextId = 0
     __channels = {}
   }
 
@@ -110,13 +110,11 @@ class AudioEngine {
   static play(name, volume, loop, pan) {
     var channel = SystemChannel.new(name)
     channel.audio = load(name)
-    __channels[__nextId] = channel
     channel.volume = volume
     channel.pan = pan
     channel.loop = loop
-
-    __nextId = __nextId + 1
     f_push(channel)
+    __channels[channel.id] = channel
     return channel
   }
 

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -73,9 +73,7 @@ class AudioEngine {
     __files = {}
     __nextId = 0
     __channels = {}
-    f_captureVariable()
   }
-  foreign static f_captureVariable()
 
   static register(name, path) {
     __nameMap[name] = path
@@ -122,9 +120,10 @@ class AudioEngine {
     return channel
   }
 
+  foreign static f_stopAllChannels()
   static stopAllChannels() {
     // TODO: foreign call
-    __channels.values.each { |channel| channel.stop() }
+    f_stopAllChannels()
   }
 
   foreign static f_update(list)

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -31,6 +31,7 @@ class AudioChannel {}
 // Encapsulates the data of the currently playing channel
 foreign class SystemChannel is AudioChannel {
   construct new(soundId) {
+    // Sensible defaults
     volume = 1
     pan = 0
     enabled = true
@@ -77,6 +78,7 @@ class AudioEngine {
   static register(name, path) {
     __nameMap[name] = path
   }
+
   static load(name, path) {
     register(name, path)
     return load(name)

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -65,6 +65,7 @@ class AudioChannelFacade is AudioChannel {
     _loop = false
     _stopRequested = false
     _id = id
+    _channel.enabled = true
   }
 
   stop() {
@@ -198,6 +199,7 @@ class AudioEngine {
     channel.loop = loop
 
     __nextId = __nextId + 1
+    f_push(systemChannel)
     return channel
   }
 
@@ -214,7 +216,7 @@ class AudioEngine {
         facade.release_()
         return false
       }
-      facade.update_()
+      // facade.update_()
       if (facade.state == AudioState.STOPPED) {
         __channels.remove(facade.id)
         return false

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -96,7 +96,6 @@ class AudioEngine {
   static unload(name) {
     var path = __nameMap[name]
     __files.remove(path)
-    __nameMap.remove(name)
     System.gc()
   }
 

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -70,6 +70,7 @@ class AudioChannelFacade is AudioChannel {
 
   stop() {
     _stopRequested = true
+    _channel.enabled = false
   }
 
   release_() {

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -95,12 +95,13 @@ class AudioEngine {
   }
 
   static unload(name) {
-    // TODO: deprecate
-    __unloadQueue.add(name)
+    var path = __nameMap[name]
+    __files.remove(path)
+    __nameMap.remove(name)
+    System.gc()
   }
 
   static unloadAll() {
-    // TODO: deprecate
     __nameMap.keys.each {|key| unload(key) }
   }
 
@@ -120,12 +121,11 @@ class AudioEngine {
     return channel
   }
 
-  foreign static f_stopAllChannels()
   static stopAllChannels() {
-    // TODO: foreign call
     f_stopAllChannels()
   }
 
+  foreign static f_stopAllChannels()
   foreign static f_update(list)
   foreign static f_push(channel)
 }

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -129,7 +129,7 @@ class AudioChannelFacade is AudioChannel {
 
   // Public
   position { _position || _channel.position }
-  position=(v) { _position = v }
+  position=(v) { _channel.position = v }
   length { _length }
   soundId { _soundId }
   volume { _volume }

--- a/src/modules/map.c
+++ b/src/modules/map.c
@@ -51,10 +51,7 @@ MAP_getSource(MAP* map, const char* moduleName) {
     return NULL;
   }
 
-  size_t sourceLen = strlen(module->source);
-  char* file = calloc(sourceLen + 1, sizeof(char));
-  strcpy(file, module->source);
-  file[sourceLen] = '\0';
+  const char* file = strdup(module->source);
   return file;
 }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -271,6 +271,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_addFunction(&engine->moduleMap, "audio", "AudioData.length", AUDIO_getLength);
 
   MAP_addFunction(&engine->moduleMap, "audio", "static AudioEngine.f_update(_)", AUDIO_ENGINE_update);
+  MAP_addFunction(&engine->moduleMap, "audio", "static AudioEngine.f_push(_)", AUDIO_ENGINE_push);
   MAP_addFunction(&engine->moduleMap, "audio", "static AudioEngine.f_captureVariable()", AUDIO_ENGINE_capture);
 
   // FileSystem

--- a/src/vm.c
+++ b/src/vm.c
@@ -176,7 +176,7 @@ internal void VM_error(WrenVM* vm, WrenErrorType type, const char* module,
 
 internal const char*
 VM_resolve_module_name(WrenVM* vm, const char* importer, const char* name) {
-  char* localName = name;
+  const char* localName = name;
   if (strlen(name) > 1) {
     while (localName[0] == '.' && localName[1] == '/') {
       localName = localName + 2;

--- a/src/vm.c
+++ b/src/vm.c
@@ -271,7 +271,6 @@ internal WrenVM* VM_create(ENGINE* engine) {
 
   MAP_addFunction(&engine->moduleMap, "audio", "AudioData.length", AUDIO_getLength);
 
-  MAP_addFunction(&engine->moduleMap, "audio", "static AudioEngine.f_update(_)", AUDIO_ENGINE_update);
   MAP_addFunction(&engine->moduleMap, "audio", "static AudioEngine.f_push(_)", AUDIO_ENGINE_push);
   MAP_addFunction(&engine->moduleMap, "audio", "static AudioEngine.f_stopAllChannels()", AUDIO_ENGINE_wrenStopAll);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -272,7 +272,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
 
   MAP_addFunction(&engine->moduleMap, "audio", "static AudioEngine.f_update(_)", AUDIO_ENGINE_update);
   MAP_addFunction(&engine->moduleMap, "audio", "static AudioEngine.f_push(_)", AUDIO_ENGINE_push);
-  MAP_addFunction(&engine->moduleMap, "audio", "static AudioEngine.f_captureVariable()", AUDIO_ENGINE_capture);
+  MAP_addFunction(&engine->moduleMap, "audio", "static AudioEngine.f_stopAllChannels()", AUDIO_ENGINE_wrenStopAll);
 
   // FileSystem
   MAP_addFunction(&engine->moduleMap, "io", "static FileSystem.f_load(_,_)", FILESYSTEM_loadAsync);

--- a/src/vm.c
+++ b/src/vm.c
@@ -252,7 +252,6 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_addFunction(&engine->moduleMap, "image", "DrawCommand.draw(_,_)", DRAW_COMMAND_draw);
 
   // Audio
-  MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.enabled=(_)", AUDIO_CHANNEL_setEnabled);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.enabled", AUDIO_CHANNEL_getEnabled);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.loop=(_)", AUDIO_CHANNEL_setLoop);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.loop", AUDIO_CHANNEL_getLoop);
@@ -263,6 +262,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.position=(_)", AUDIO_CHANNEL_setPosition);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.state=(_)", AUDIO_CHANNEL_setState);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.audio=(_)", AUDIO_CHANNEL_setAudio);
+  MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.stop()", AUDIO_CHANNEL_stop);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.state", AUDIO_CHANNEL_getState);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.length", AUDIO_CHANNEL_getLength);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.position", AUDIO_CHANNEL_getPosition);

--- a/src/vm.c
+++ b/src/vm.c
@@ -267,6 +267,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.length", AUDIO_CHANNEL_getLength);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.position", AUDIO_CHANNEL_getPosition);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.soundId", AUDIO_CHANNEL_getSoundId);
+  MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.id", AUDIO_CHANNEL_getId);
 
   MAP_addFunction(&engine->moduleMap, "audio", "AudioData.length", AUDIO_getLength);
 


### PR DESCRIPTION
This PR does a few things around the audio engine:

1) Creates a GenericChannel which can be played by the audio engine. This is necessary so that C-side code can easily output arbitrary sound data.
2) The AudioChannel now implements the GenericChannel "interface", and most of the "AudioChannelFacade" functions (including the state machine) have now been pushed from the Wren layer to the C layer.
3) We now have the ability to run a rudimentary resampling algorithm over incoming audio data. This means we can accept data using any sample rate, although CD quality audio is still recommended. Resampling is performed during file load, and is very slow. This is a good candidate for asynchronous operations in the future.