### PR TITLE
Implemented wren2c command

### DIFF
--- a/scripts/setup_wren.sh
+++ b/scripts/setup_wren.sh
@@ -4,7 +4,7 @@ INCLUDE_DIR=$DOME_DIR/include
 LIB_DIR=$DOME_DIR/lib
 WREN_DIR=$LIB_DIR/wren
 
-cd $WREN_DIR/projects
+cd "$WREN_DIR/projects"
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   # ...
@@ -27,9 +27,9 @@ MAKEFLAGS="--no-print-directory"
 # build the debug version of wren
 make clean
 CFLAGS=-fvisibility=hidden
-make ${@:2} CFLAGS=${CFLAGS} verbose=1 config=debug_$1 wren && cp $WREN_DIR/lib/libwren_d.a $LIB_DIR/libwrend.a
+make ${@:2} CFLAGS=${CFLAGS} verbose=1 config=debug_$1 wren && cp "$WREN_DIR/lib/libwren_d.a" "$LIB_DIR/libwrend.a"
 # build the release version of wren
 make clean
-make ${@:2} CFLAGS=${CFLAGS} verbose=1 config=release_$1 wren && cp $WREN_DIR/lib/libwren.a $LIB_DIR/libwren.a
+make ${@:2} CFLAGS=${CFLAGS} verbose=1 config=release_$1 wren && cp "$WREN_DIR/lib/libwren.a" "$LIB_DIR/libwren.a"
 # Copy the wren.h to our includes
-cp $WREN_DIR/src/include/wren.h $INCLUDE_DIR/wren.h
+cp "$WREN_DIR/src/include/wren.h" "$INCLUDE_DIR/wren.h"

--- a/src/main.c
+++ b/src/main.c
@@ -94,8 +94,8 @@ global_variable size_t GIF_SCALE = 1;
 #include "plugin.h"
 #include "engine.h"
 #include "util/font8x8.h"
-#include "util/wren2c.c"
 #include "io.c"
+#include "util/wren2c.c"
 
 #include "audio/engine.h"
 #include "audio/hashmap.c"
@@ -446,6 +446,7 @@ int main(int argc, char* args[])
         printVersion(&engine);
         goto cleanup;
       case 'w':
+        WREN2C_encodeAndDump(&engine, argc, args);
         goto cleanup;
       case '?':
         fprintf(stderr, "%s: %s\n", args[0], options.errmsg);

--- a/src/main.c
+++ b/src/main.c
@@ -94,6 +94,7 @@ global_variable size_t GIF_SCALE = 1;
 #include "plugin.h"
 #include "engine.h"
 #include "util/font8x8.h"
+#include "util/wren2c.c"
 #include "io.c"
 
 #include "audio/engine.h"
@@ -359,6 +360,7 @@ printUsage(ENGINE* engine) {
   ENGINE_printLog(engine, "  -h --help           Show this screen.\n");
   ENGINE_printLog(engine, "  -r --record=<gif>   Record video to <gif>.\n");
   ENGINE_printLog(engine, "  -v --version        Show version.\n");
+  ENGINE_printLog(engine, "  -w --wren2c         Converts a Wren file to a C string.\n");
 }
 
 int main(int argc, char* args[])
@@ -387,6 +389,7 @@ int main(int argc, char* args[])
     {"version", 'v', OPTPARSE_NONE},
     {"record", 'r', OPTPARSE_OPTIONAL},
     {"scale", 's', OPTPARSE_REQUIRED},
+    {"wren2c", 'w', OPTPARSE_REQUIRED},
     {0}
   };
 
@@ -441,6 +444,8 @@ int main(int argc, char* args[])
       case 'v':
         printTitle(&engine);
         printVersion(&engine);
+        goto cleanup;
+      case 'w':
         goto cleanup;
       case '?':
         fprintf(stderr, "%s: %s\n", args[0], options.errmsg);

--- a/src/util/wren2c.c
+++ b/src/util/wren2c.c
@@ -1,0 +1,119 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+char* WREN2C_hash(char *key)
+{
+    // https://en.wikipedia.org/wiki/Jenkins_hash_function
+    // http://www.burtleburtle.net/bob/hash/doobs.html
+    int len = strlen(key);
+    uint32_t hash, i;
+    for(hash = i = 0; i < len; ++i)
+    {
+        hash += key[i];
+        hash += (hash << 10);
+        hash ^= (hash >> 6);
+    }
+    hash += (hash << 3);
+    hash ^= (hash >> 11);
+    hash += (hash << 15);
+
+    char out[10];
+    sprintf(out, "%d", hash);
+
+    return out;
+}
+
+char* WREN2C_readEntireFile(char* path, size_t* lengthPtr) {
+  FILE* file = fopen(path, "r");
+  if (file == NULL) {
+    return NULL;
+  }
+  char* source = NULL;
+  if (fseek(file, 0L, SEEK_END) == 0) {
+    /* Get the size of the file. */
+    long bufsize = ftell(file);
+    /* Allocate our buffer to that size. */
+    source = malloc(sizeof(char) * (bufsize + 1));
+
+    /* Go back to the start of the file. */
+    if (fseek(file, 0L, SEEK_SET) != 0) { /* Error */ }
+
+    /* Read the entire file into memory. */
+    size_t newLen = fread(source, sizeof(char), bufsize, file);
+    if ( ferror( file ) != 0 ) {
+      fputs("Error reading file", stderr);
+    } else {
+      if (lengthPtr != NULL) {
+        *lengthPtr = newLen;
+      }
+      source[newLen++] = '\0'; /* Just to be safe. */
+    }
+  }
+  fclose(file);
+  return source;
+}
+
+
+void WREN2C_encodeAndDump(ENGINE* engine, int argc, char* args[]) {
+  
+  char* fileName = args[1];
+
+  char* name;
+  sprintf(name, "%s.inc", fileName);
+
+  char* fileOut = strdup(name); 
+
+  sprintf(name, "wrenModule_%s", WREN2C_hash(fileName));  
+  char* moduleName = strdup(name);
+
+  if (argc == 2) {
+    moduleName = args[2];
+  }
+
+  if (argc == 3) {
+    fileOut = args[3];
+  }
+
+  size_t length;
+  char* fileToConvert = readEntireFile(fileName, &length);
+
+  FILE *fp;
+  fp = fopen(fileOut, "w+");
+  fputs("// Generated automatically using ./dome --wren2c ", fp);
+  fputs(fileName);
+  fputs(" Do not modify\n");
+
+  fputs("static const char ", fp);
+  fputs(moduleName, fp);
+
+  fputs("[", fp);
+  fprintf(fp, "%li", length + 1);
+  fputs("] = {", fp);
+  
+  for (size_t i = 0; i < length; i++ ) {
+    char* ptr = fileToConvert + i;
+  
+    if (*ptr == '\n') {
+      fputs("'\\n',", fp);
+      fputs("\n", fp);
+    } else {
+      fputs("'", fp);
+      if (*ptr == '\'') {
+        fputs("\\\'", fp);
+      else if (*ptr == '"') {
+        fputs("\\\"", fp);
+      } else {
+        fwrite(ptr, sizeof(char), 1, fp);
+      }
+      fputs("', ", fp);
+    }
+  }
+  fputs("\0", fp);
+
+  fputs(" };\n", fp);
+
+  fclose(fp);
+  free(fileToConvert);
+  free(name);
+}

--- a/src/util/wren2c.h
+++ b/src/util/wren2c.h
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+char* WREN2C_readEntireFile(char* path, size_t* lengthPtr);
+void WREN2C_encodeAndDump(ENGINE* engine, char* args[]);

--- a/src/util/wren2c.h
+++ b/src/util/wren2c.h
@@ -1,6 +1,0 @@
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-
-char* WREN2C_readEntireFile(char* path, size_t* lengthPtr);
-void WREN2C_encodeAndDump(ENGINE* engine, char* args[]);


### PR DESCRIPTION
Simple command that helps plugin development by transforming _Wren_ code to _C_ strings.

Usage: `./dome --wren2c <input> <module name>? <output>?`

- input: File to read.
- module name: Optional. If not present will use a random string.
- output: Optional. If not present will use the input + .inc extension. (E.g. `main.wren.inc`)

Example: 

- `./dome --wren2c main.wren`
- `./dome -w main.wren` (shorthand)

Output:

```c
// Generated automatically using ./dome --wren2c main.wren Do not modify
const char wrenModule_oFWKSfTl2n[196] = {'i', 'm', 'p', 'o', 'r', 't', ' ', '"', 'g', 'r', 'a', 'p', 'h', 'i', 'c', 's', '"', ' ', 'f', 'o', 'r', ' ', 'C', 'a', 'n', 'v', 'a', 's', ',', ' ', 'C', 'o', 'l', 'o', 'r', '\n',
'c', 'l', 'a', 's', 's', ' ', 'G', 'a', 'm', 'e', ' ', '{', '\n',
' ', ' ', ' ', ' ', 's', 't', 'a', 't', 'i', 'c', ' ', 'i', 'n', 'i', 't', '(', ')', ' ', '{', '}', '\n',
' ', ' ', ' ', ' ', 's', 't', 'a', 't', 'i', 'c', ' ', 'u', 'p', 'd', 'a', 't', 'e', '(', ')', ' ', '{', '}', '\n',
' ', ' ', ' ', ' ', 's', 't', 'a', 't', 'i', 'c', ' ', 'd', 'r', 'a', 'w', '(', 'd', 't', ')', ' ', '{', '\n',
' ', ' ', ' ', ' ', ' ', ' ', 'C', 'a', 'n', 'v', 'a', 's', '.', 'p', 'r', 'i', 'n', 't', '(', '"', 'D', 'O', 'M', 'E', ' ', 'I', 'n', 's', 't', 'a', 'l', 'l', 'e', 'd', ' ', 'S', 'u', 'c', 'c', 'e', 's', 's', 'f', 'u', 'l', 'l', 'y', '.', '"', ',', ' ', '1', '0', ',', ' ', '1', '0', ',', ' ', 'C', 'o', 'l', 'o', 'r', '.', 'w', 'h', 'i', 't', 'e', ')', '\n',
' ', ' ', ' ', ' ', '}', '\n',
'}', '\n',
 };
```

The code was just recycling the contents of `utils/encode.c` with some minor adjustments.
