### PR TITLE
Newline support for fonts

### DIFF
--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -60,6 +60,7 @@ Offset all following draw operations by (_x, y_). Calling this without arguments
 
 #### `static print(str, x: Number, y: Number, c: Color) `
 Print the text _str_ with the top-left corner at (_x, y_) in color _c_, using the currently set default font. See `Canvas.font` for more information.
+If a newline `\n` is in the string, the text will broken over multiple lines with a spacing of `fontHeight / 4`. _The spacing is currently not customizable, but will be later_
 
 #### `static print(str, x: Number, y: Number, c: Color, fontName: String) `
 Print the text _str_ with the top-left corner at (_x, y_) in color _c_, in the specified font.

--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -60,10 +60,13 @@ Offset all following draw operations by (_x, y_). Calling this without arguments
 
 #### `static print(str, x: Number, y: Number, c: Color) `
 Print the text _str_ with the top-left corner at (_x, y_) in color _c_, using the currently set default font. See `Canvas.font` for more information.
-If a newline `\n` is in the string, the text will broken over multiple lines with a spacing of `fontHeight / 4`. _The spacing is currently not customizable, but will be later_
+The text will be split across multiple lines if a newline (`\n`) character is encountered.
+The vertical line spacing defaults to `fontHeight / 4`, where fontHeight is the maximum height of a font character in pixels, but this will be configurable in future versions of DOME.
 
 #### `static print(str, x: Number, y: Number, c: Color, fontName: String) `
 Print the text _str_ with the top-left corner at (_x, y_) in color _c_, in the specified font.
+The text will be split across multiple lines if a newline (`\n`) character is encountered.
+The vertical line spacing is calculated for each font, but this will be configurable in future versions of DOME.
 
 #### `static pset(x: Number, y: Number, c: Color) `
 Set the pixel at (_x, y_) to the color _c_.

--- a/src/engine.c
+++ b/src/engine.c
@@ -485,7 +485,6 @@ defaultFontLookup(utf8_int32_t codepoint) {
 
 internal void
 ENGINE_print(ENGINE* engine, char* text, int64_t x, int64_t y, uint32_t c) {
-  int newlines = 0;
   int fontWidth = 8;
   int fontHeight = 8;
   int spacing = (fontHeight / 4);
@@ -495,8 +494,8 @@ ENGINE_print(ENGINE* engine, char* text, int64_t x, int64_t y, uint32_t c) {
   size_t len = utf8len(text);
   for (size_t pos = 0; pos < len; pos++) {
     if (text[pos] == '\n') {
-      newlines++;
       cursor = 0;
+      y += fontHeight + spacing;
       v = utf8codepoint(v, &codepoint);
       continue;
     }
@@ -506,7 +505,7 @@ ENGINE_print(ENGINE* engine, char* text, int64_t x, int64_t y, uint32_t c) {
       for (int i = 0; i < fontWidth; i++) {
         uint8_t v = (glyph[j] >> i) & 1;
         if (v != 0) {
-          ENGINE_pset(engine, x + cursor + i, y + (fontHeight * newlines) + j + (spacing * newlines), c);
+          ENGINE_pset(engine, x + cursor + i, y + j, c);
         }
       }
     }

--- a/src/engine.c
+++ b/src/engine.c
@@ -485,19 +485,28 @@ defaultFontLookup(utf8_int32_t codepoint) {
 
 internal void
 ENGINE_print(ENGINE* engine, char* text, int64_t x, int64_t y, uint32_t c) {
+  int newlines = 0;
   int fontWidth = 8;
   int fontHeight = 8;
+  int spacing = (fontHeight / 4);
   int cursor = 0;
   utf8_int32_t codepoint;
   void* v = utf8codepoint(text, &codepoint);
   size_t len = utf8len(text);
   for (size_t pos = 0; pos < len; pos++) {
+    if (text[pos] == '\n') {
+      newlines++;
+      cursor = 0;
+      v = utf8codepoint(v, &codepoint);
+      continue;
+    }
+
     uint8_t* glyph = (uint8_t*)defaultFontLookup(codepoint);
     for (int j = 0; j < fontHeight; j++) {
       for (int i = 0; i < fontWidth; i++) {
         uint8_t v = (glyph[j] >> i) & 1;
         if (v != 0) {
-          ENGINE_pset(engine, x + cursor + i, y + j, c);
+          ENGINE_pset(engine, x + cursor + i, y + (fontHeight * newlines) + j + (spacing * newlines), c);
         }
       }
     }

--- a/src/modules/font.c
+++ b/src/modules/font.c
@@ -7,7 +7,6 @@ typedef struct {
   FONT* font;
   float scale;
   int height;
-  int spacing;
 
   bool antialias;
   int32_t offsetY;
@@ -52,8 +51,7 @@ FONT_RASTER_allocate(WrenVM* vm) {
 
   int ascent, descent, linegap;
   stbtt_GetFontVMetrics(&font->info, &ascent, &descent, &linegap);
-  raster->height = (ascent - descent) * (raster->scale);
-  raster->spacing = linegap * (raster->scale);
+  raster->height = (ascent - descent + linegap) * (raster->scale);
 
   int32_t x0, x1, y0, y1;
   stbtt_GetFontBoundingBox(&font->info, &x0, &x1, &y0, &y1);
@@ -91,7 +89,6 @@ FONT_RASTER_print(WrenVM* vm) {
 
   int fontHeight = raster->height;
   int newlines = 0;
-  //int spacing = raster->spacing;
 
   float scale = raster->scale;
   int32_t offsetY = raster->offsetY;

--- a/src/modules/font.c
+++ b/src/modules/font.c
@@ -88,7 +88,6 @@ FONT_RASTER_print(WrenVM* vm) {
   int w, h;
 
   int fontHeight = raster->height;
-  int newlines = 0;
 
   float scale = raster->scale;
   int32_t offsetY = raster->offsetY;
@@ -101,9 +100,9 @@ FONT_RASTER_print(WrenVM* vm) {
   void* v = utf8codepoint(text, &codepoint);
   for (int charIndex = 0; charIndex < len; charIndex++) {
     if (text[charIndex] == '\n') {
-      newlines++;
-      v = utf8codepoint(v, &codepoint);
       posX = x;
+      baseY += fontHeight;
+      v = utf8codepoint(v, &codepoint);
       continue;
     }
     int ax;
@@ -124,7 +123,7 @@ FONT_RASTER_print(WrenVM* vm) {
         } else {
           outColor = bitmap[j * w + i] > 0 ? color : 0;
         }
-        ENGINE_pset(engine, posX + i, posY + (fontHeight * newlines) + j, outColor);
+        ENGINE_pset(engine, posX + i, posY + j, outColor);
       }
     }
     posX += ax * scale;


### PR DESCRIPTION
This adds newline support in for Canvas.print(). A default spacing of `fontHeight / 4` has been set. The user should probably be able to customize this at some point.