### PR TITLE
Provide access to `wrenGetVariable()` and `wrenGetSlotHandle()`

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -278,6 +278,7 @@ const char*    getSlotBytes(WrenVM* vm, int slot, int* length);
       void     getVariable(WrenVM* vm, const char* module, const char* name, int slot);
    WrenHandle* getSlotHandle(WrenVM* vm, int slot);
       void     setSlotHandle(WrenVM* vm, int slot, WrenHandle* handle);
+      void     releaseHandle(WrenVM* vm, WrenHandle* handle);
 ```
 
 ## Audio

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -274,6 +274,9 @@ const char*    getSlotBytes(WrenVM* vm, int slot, int* length);
       void     getMapValue(WrenVM* vm, int mapSlot, int keySlot, int valueSlot);
       void     setMapValue(WrenVM* vm, int mapSlot, int keySlot, int valueSlot);
       void     removeMapValue(WrenVM* vm, int mapSlot, int keySlot, int removedValueSlot);
+
+      void     getVariable(WrenVM* vm, const char* module, const char* name, int slot);
+   WrenHandle* getSlotHandle(WrenVM* vm, int slot);
 ```
 
 ## Audio

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -277,6 +277,7 @@ const char*    getSlotBytes(WrenVM* vm, int slot, int* length);
 
       void     getVariable(WrenVM* vm, const char* module, const char* name, int slot);
    WrenHandle* getSlotHandle(WrenVM* vm, int slot);
+      void     setSlotHandle(WrenVM* vm, int slot, WrenHandle* handle);
 ```
 
 ## Audio

--- a/include/dome.h
+++ b/include/dome.h
@@ -131,6 +131,7 @@ typedef struct {
 
   void (*getVariable)(WrenVM* vm, const char* module, const char* name, int slot);
   WrenHandle* (*getSlotHandle)(WrenVM* vm, int slot);
+  void (*setSlotHandle)(WrenVM* vm, int slot, WrenHandle* handle);
 } WREN_API_v0;
 
 typedef struct {

--- a/include/dome.h
+++ b/include/dome.h
@@ -59,6 +59,7 @@ typedef enum {
 #ifndef wren_h
 // If the wren header is not in use, we forward declare some types we need.
 typedef struct WrenVM WrenVM;
+typedef struct WrenHandle WrenHandle;
 typedef void (*WrenForeignMethodFn)(WrenVM* vm);
 typedef void (*WrenFinalizerFn)(void* data);
 
@@ -127,6 +128,9 @@ typedef struct {
   void (*getMapValue)(WrenVM* vm, int mapSlot, int keySlot, int valueSlot);
   void (*setMapValue)(WrenVM* vm, int mapSlot, int keySlot, int valueSlot);
   void (*removeMapValue)(WrenVM* vm, int mapSlot, int keySlot, int removedValueSlot);
+
+  void (*getVariable)(WrenVM* vm, const char* module, const char* name, int slot);
+  WrenHandle* (*getSlotHandle)(WrenVM* vm, int slot);
 } WREN_API_v0;
 
 typedef struct {

--- a/include/dome.h
+++ b/include/dome.h
@@ -132,6 +132,7 @@ typedef struct {
   void (*getVariable)(WrenVM* vm, const char* module, const char* name, int slot);
   WrenHandle* (*getSlotHandle)(WrenVM* vm, int slot);
   void (*setSlotHandle)(WrenVM* vm, int slot, WrenHandle* handle);
+  void (*releaseHandle)(WrenVM* vm, WrenHandle* handle);
 } WREN_API_v0;
 
 typedef struct {

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -318,7 +318,10 @@ WREN_API_v0 wren_v0 = {
   .getMapContainsKey = wrenGetMapContainsKey,
   .getMapValue = wrenGetMapValue,
   .setMapValue = wrenSetMapValue,
-  .removeMapValue = wrenRemoveMapValue
+  .removeMapValue = wrenRemoveMapValue,
+
+  .getVariable = wrenGetVariable,
+  .getSlotHandle = wrenGetSlotHandle
 };
 
 DOME_API_v0 dome_v0 = {

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -322,7 +322,8 @@ WREN_API_v0 wren_v0 = {
 
   .getVariable = wrenGetVariable,
   .getSlotHandle = wrenGetSlotHandle,
-  .setSlotHandle = wrenSetSlotHandle
+  .setSlotHandle = wrenSetSlotHandle,
+  .releaseHandle = wrenReleaseHandle
 };
 
 DOME_API_v0 dome_v0 = {

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -321,7 +321,8 @@ WREN_API_v0 wren_v0 = {
   .removeMapValue = wrenRemoveMapValue,
 
   .getVariable = wrenGetVariable,
-  .getSlotHandle = wrenGetSlotHandle
+  .getSlotHandle = wrenGetSlotHandle,
+  .setSlotHandle = wrenSetSlotHandle
 };
 
 DOME_API_v0 dome_v0 = {


### PR DESCRIPTION
`wrenSetSlotNewForeign()` cannot be used for something other than foreign allocator if they are not provided.