### PR TITLE
TTF Font Area Calculation

### DIFF
--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -50,6 +50,9 @@ Draw an ellipse between (_x0, y0_) and (_x1, y1_) in the color _c_.
 #### `static ellipsefill(x0: Number, y0: Number, x1: Number, y1: Number, c: Color) `
 Draw a filled ellipse between (_x0, y0_) and (_x1, y1_) in the color _c_.
 
+#### `static getPrintArea(text: String): Vector`
+Return a [Vector](./math#vector) representing the maximum height and width needed to draw `text` in the current default font.
+
 #### `static line(x0: Number, y0: Number, x1: Number, y1: Number, c: Color) `
 #### `static line(x0: Number, y0: Number, x1: Number, y1: Number, c: Color, size: Number) `
 Draw a line `size` pixels wide between (_x0, y0_) and (_x1, y1_) in the color _c_. By default, `size` is 1.
@@ -171,6 +174,9 @@ Load the font file at `path`, rasterize it to the pixel height of `size`, and ma
 You can retrieve a specific font using the index operator, for example `Font["NewFont"]`.
 
 ### Instance Methods
+#### `getArea(text: String): Vector`
+Calculate the maximum size that this font will take to print `text` to the display. Returns as a [`Vector`](./math#vector) of `(width, height)`.
+
 #### `print(text: String, x: Number, y: Number, color: Color): Void`
 Print the `text` on the canvas at `(x, y)`, in the given `color`.
 

--- a/examples/fonts/main.wren
+++ b/examples/fonts/main.wren
@@ -8,15 +8,23 @@ class Main {
     Font.load("memory", "memory.ttf", 50)
     Font.load("memory_small", "memory.ttf", 16)
     Font["memory"].antialias = true
+    _pos = Font["memory_small"].getArea("Hello\nworld")
     Canvas.font = "memory"
+    System.print(_pos)
+
   }
 
   update() {}
 
   draw(dt) {
     Canvas.cls()
-    Canvas.print("The quick brown fox jumps over the lazy dog", 0, 120, Color.hsv(80, 1, 1), "memory_small")
-    Canvas.print("DOME Installed Successfully.", 10, 10, Color.white)
+    Canvas.rect(0, 0, _pos.x, _pos.y, Color.red)
+
+    Canvas.print("Hello\nworld", 0, 0, Color.hsv(80, 1, 1), "memory_small")
+    Canvas.print("The quick brown fox jumps over the lazy dog", 0, 60, Color.hsv(80, 1, 1), "memory_small")
+    var pos = Canvas.getPrintArea("DOME Installed\nSuccessfully.")
+    Canvas.rect(10, 80, pos.x, pos.y, Color.red)
+    Canvas.print("DOME Installed\nSuccessfully.", 10, 80, Color.white)
   }
 }
 

--- a/examples/fonts/main.wren
+++ b/examples/fonts/main.wren
@@ -5,13 +5,13 @@ class Main {
   construct new() {}
 
   init() {
+    _defaultPos = Canvas.getPrintArea("Hello world")
+
     Font.load("memory", "memory.ttf", 50)
     Font.load("memory_small", "memory.ttf", 16)
     Font["memory"].antialias = true
     _pos = Font["memory_small"].getArea("Hello\nworld")
     Canvas.font = "memory"
-    System.print(_pos)
-
   }
 
   update() {}
@@ -25,6 +25,9 @@ class Main {
     var pos = Canvas.getPrintArea("DOME Installed\nSuccessfully.")
     Canvas.rect(10, 80, pos.x, pos.y, Color.red)
     Canvas.print("DOME Installed\nSuccessfully.", 10, 80, Color.white)
+
+    Canvas.rect(10, 160, _defaultPos.x, _defaultPos.y, Color.red)
+    Canvas.print("Hello\nworld", 10, 160, Color.white, Font.default)
   }
 }
 

--- a/src/modules/font.wren
+++ b/src/modules/font.wren
@@ -1,4 +1,5 @@
 import "io" for FileSystem
+import "math" for Vector
 
 foreign class FontFile {
   construct parse(data) {}
@@ -34,6 +35,12 @@ foreign class RasterizedFont is Font {
   construct parse(file, size) {}
   foreign antialias=(v)
   foreign f_print(text, x, y, color)
+  foreign f_getArea(str)
+
+  getArea(str) {
+    var pos = f_getArea(str)
+    return Vector.new(pos[0], pos[1])
+  }
 
   print(text, x, y, color) {
     f_print(text, x, y, color.toNum)

--- a/src/modules/graphics.wren
+++ b/src/modules/graphics.wren
@@ -133,6 +133,13 @@ class Canvas {
     }
   }
 
+  static getPrintArea(str) {
+    if (__defaultFont != null) {
+      return Font[__defaultFont].getArea(str)
+    }
+    return str.count * 8
+  }
+
   foreign static f_cls(color)
   static cls() {
     cls(Color.black)

--- a/src/modules/graphics.wren
+++ b/src/modules/graphics.wren
@@ -114,6 +114,12 @@ class Canvas {
   static print(str, x, y, c, font) {
     if (Font[font] != null) {
       Font[font].print(str, x, y, c)
+    } else if (font == Font.default) {
+      var color = Color.white
+      if (c is Color) {
+        color = c
+      }
+      f_print(str, x, y, color.toNum)
     } else {
       Fiber.abort("Font %(font) is not loaded")
     }
@@ -134,10 +140,13 @@ class Canvas {
   }
 
   static getPrintArea(str) {
-    if (__defaultFont != null) {
+    if (__defaultFont != Font.default) {
       return Font[__defaultFont].getArea(str)
     }
-    return str.count * 8
+    var lines = str.split("\n")
+    var maxX = lines.map {|line| line.count }.reduce(0) {|acc, value| acc > value ? acc : value }
+    var vSpacing = 8 / 4
+    return Vector.new(maxX * 8, lines.count * (vSpacing + 8) - vSpacing - 1)
   }
 
   foreign static f_cls(color)

--- a/src/util/wrenembed.c
+++ b/src/util/wrenembed.c
@@ -13,13 +13,13 @@ char* WRENEMBED_readEntireFile(char* path, size_t* lengthPtr)
   if (file == NULL) {
     return NULL;
   }
-  
+
   char* source = NULL;
   if (fseek(file, 0L, SEEK_END) == 0) {
-    
+
     // Get the size of the file.
     long bufsize = ftell(file);
-    
+
     // Allocate our buffer to that size.
     source = malloc(sizeof(char) * (bufsize + 1));
 
@@ -30,12 +30,12 @@ char* WRENEMBED_readEntireFile(char* path, size_t* lengthPtr)
 
     // Read the entire file into memory.
     size_t newLen = fread(source, sizeof(char), bufsize, file);
-    
+
     if (ferror(file) != 0) {
       fclose(file);
       return NULL;
     }
-    
+
     if (lengthPtr != NULL) {
       *lengthPtr = newLen;
     }
@@ -71,7 +71,7 @@ int WRENEMBED_encodeAndDump(int argc, char* args[])
     // TODO: Maybe sanitize moduleName to be valid C identifier?
     moduleName = args[2];
   }
-  
+
   FILE *fp;
   if(argc > 3) {
     fp = fopen(args[3], "w+");
@@ -99,6 +99,8 @@ int WRENEMBED_encodeAndDump(int argc, char* args[])
       // TODO: Properly test the encoding with different source files
       if (*ptr == '\'') {
         fputs("\\\'", fp);
+      } else if (*ptr == '\\') {
+        fputs("\\\\", fp);
       } else {
         fwrite(ptr, sizeof(char), 1, fp);
       }

--- a/src/vm.c
+++ b/src/vm.c
@@ -206,6 +206,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_addClass(&engine->moduleMap, "font", "FontFile", FONT_allocate, FONT_finalize);
   MAP_addClass(&engine->moduleMap, "font", "RasterizedFont", FONT_RASTER_allocate, FONT_RASTER_finalize);
   MAP_addFunction(&engine->moduleMap, "font", "RasterizedFont.f_print(_,_,_,_)", FONT_RASTER_print);
+  MAP_addFunction(&engine->moduleMap, "font", "RasterizedFont.f_getArea(_)", FONT_RASTER_getArea);
   MAP_addFunction(&engine->moduleMap, "font", "RasterizedFont.antialias=(_)", FONT_RASTER_setAntiAlias);
   MAP_lockModule(&engine->moduleMap, "font");
 


### PR DESCRIPTION
`RasterisedFont.getArea` and `Canvas.getPrintArea` allow access to the font draw size, for figuring out wrapping and justification of text.