### PR TITLE
Glibc compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ endif
 
 LDFLAGS = -L$(LIBS) $(WINDOW_MODE_FLAG) $(SDLFLAGS) $(STATIC_FLAG)
 ifneq ($(filter linux,$(TAGS)),)
+	COMPAT_DEP = $(OBJS)/glibc_compat.o
 	LDFLAGS += -Wl,--wrap=log,--wrap=log2,--wrap=exp,--wrap=pow
 endif
 LDFLAGS += $(DEPS)
@@ -175,6 +176,11 @@ $(MODULES)/*.inc: $(UTILS)/embed.c $(MODULES)/*.wren
 	@echo "==== Building DOME modules  ===="
 	./scripts/generateEmbedModules.sh
 
+$(OBJS)/glibc_compat.o: $(INCLUDES)/glibc_compat.c
+	@mkdir -p $(OBJS)
+	@echo "==== Building glibc_compat module ===="
+	$(CC) $(CFLAGS) -c $(INCLUDES)/glibc_compat.c -o $(OBJS)/glibc_compat.o $(IFLAGS)
+
 $(OBJS)/vendor.o: $(INCLUDES)/vendor.c
 	@mkdir -p $(OBJS)
 	@echo "==== Building vendor module ===="
@@ -185,7 +191,7 @@ $(OBJS)/main.o: $(SOURCE_FILES) $(INCLUDES) $(WREN_LIB) $(MODULES)/*.inc
 	@echo "==== Building core ($(TAGS)) module ===="
 	$(CC) $(CFLAGS) -c $(SOURCE)/main.c -o $(OBJS)/main.o $(IFLAGS) 
 
-$(TARGET_NAME): $(OBJS)/main.o $(OBJS)/vendor.o $(WREN_LIB)
+$(TARGET_NAME): $(OBJS)/main.o $(OBJS)/vendor.o $(COMPAT_DEP) $(WREN_LIB)
 	@echo "==== Linking DOME ($(TAGS)) ===="
 	$(CC) $(CFLAGS) $(FFLAGS) -o $(TARGET_NAME) $(OBJS)/*.o $(ICON_OBJECT_FILE) $(LDFLAGS) 
 	./scripts/set-executable-path.sh $(TARGET_NAME)

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ WARNING_FLAGS += -Wno-incompatible-pointer-types-discards-qualifiers
 else ifneq ($(filter windows,$(TAGS)),)
 WARNING_FLAGS += -Wno-discarded-qualifiers -Wno-clobbered
 else ifneq ($(filter linux,$(TAGS)),)
-	LDFLAGS += -Wl,--wrap=log,--wrap=log2,--wrap=exp,--wrap=pow
 	WARNING_FLAGS += -Wno-clobbered -Wno-maybe-uninitialized -Wno-attributes
 endif
 
@@ -148,6 +147,9 @@ FFLAGS += -F/Library/Frameworks -framework SDL2
 endif
 
 LDFLAGS = -L$(LIBS) $(WINDOW_MODE_FLAG) $(SDLFLAGS) $(STATIC_FLAG) $(DEPS) 
+ifneq ($(filter linux,$(TAGS)),)
+	LDFLAGS += -Wl,--wrap=log,--wrap=log2,--wrap=exp,--wrap=pow
+endif
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ WARNING_FLAGS += -Wno-incompatible-pointer-types-discards-qualifiers
 else ifneq ($(filter windows,$(TAGS)),)
 WARNING_FLAGS += -Wno-discarded-qualifiers -Wno-clobbered
 else ifneq ($(filter linux,$(TAGS)),)
+	LDFLAGS += -Wl,--wrap=log,--wrap=log2,--wrap=exp,--wrap=pow
 	WARNING_FLAGS += -Wno-clobbered -Wno-maybe-uninitialized -Wno-attributes
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -146,10 +146,11 @@ else ifneq ($(and $(filter macosx,$(TAGS)), $(filter framework,$(TAGS)), $(filte
 FFLAGS += -F/Library/Frameworks -framework SDL2
 endif
 
-LDFLAGS = -L$(LIBS) $(WINDOW_MODE_FLAG) $(SDLFLAGS) $(STATIC_FLAG) $(DEPS) 
+LDFLAGS = -L$(LIBS) $(WINDOW_MODE_FLAG) $(SDLFLAGS) $(STATIC_FLAG)
 ifneq ($(filter linux,$(TAGS)),)
 	LDFLAGS += -Wl,--wrap=log,--wrap=log2,--wrap=exp,--wrap=pow
 endif
+LDFLAGS += $(DEPS)
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ endif
 LDFLAGS = -L$(LIBS) $(WINDOW_MODE_FLAG) $(SDLFLAGS) $(STATIC_FLAG)
 ifneq ($(filter linux,$(TAGS)),)
 	COMPAT_DEP = $(OBJS)/glibc_compat.o
-	LDFLAGS += -Wl,--wrap=log,--wrap=log2,--wrap=exp,--wrap=pow
+	LDFLAGS += -Wl,--wrap=log,--wrap=log2,--wrap=exp,--wrap=pow,--wrap=expf,--wrap=powf,--wrap=logf
 endif
 LDFLAGS += $(DEPS)
 

--- a/include/glibc_compat.c
+++ b/include/glibc_compat.c
@@ -20,6 +20,9 @@ asm (".symver pow, pow@GLIBC_2.2.5");
 asm (".symver exp, exp@GLIBC_2.2.5");
 asm (".symver log, log@GLIBC_2.2.5");
 asm (".symver log2, log2@GLIBC_2.2.5");
+asm (".symver logf, logf@GLIBC_2.2.5");
+asm (".symver powf, powf@GLIBC_2.2.5");
+asm (".symver expf, expf@GLIBC_2.2.5");
 #undef asm
 
 // I couldn't figure out what has changed in pow, exp, log in glibc 2.29.
@@ -40,8 +43,24 @@ double __wrap_log(double x)
 {
     return log(x);
 }
+
 double __wrap_log2(double x)
 {
     return log2(x);
+}
+
+double __wrap_logf(double x)
+{
+    return logf(x);
+}
+
+double __wrap_powf(double x)
+{
+    return powf(x);
+}
+
+double __wrap_expf(double x)
+{
+    return expf(x);
 }
 #endif

--- a/include/glibc_compat.c
+++ b/include/glibc_compat.c
@@ -1,0 +1,56 @@
+/* This file is only used on GNU/Linux (ie glibc) when compiling with portable=1,
+   in order to produce binaries that don't depend on functions only present
+   in newer glibc versions.
+   Functions like fcntl are redirected by ld to __wrap_fcntl etc (see
+   SConscript), defined in this file, which are wrappers around a shadowed but
+   still present symbol in libc.so or libm.so.
+   (The .symver lines below could instead be placed in a header included everywhere
+   if we weren't linking to any libraries compiled without the header, eg libfb)
+
+   See https://rpg.hamsterrepublic.com/ohrrpgce/Portable_GNU-Linux_binaries
+   for more info and instructions for updating.
+
+   Placed in the public domain.
+*/
+
+#ifdef __linux__
+#include <stdarg.h>
+#include <math.h>
+
+#ifdef HOST_64BIT
+// x86_64 glibc... I'm guessing ARM64, etc, has the same versioned symbols
+asm (".symver pow, pow@GLIBC_2.2.5");
+asm (".symver exp, exp@GLIBC_2.2.5");
+asm (".symver log, log@GLIBC_2.2.5");
+asm (".symver log2, log@GLIBC_2.2.5");
+#else
+// x86 glibc... I'm guessing ARM32, etc, has the same versioned symbols
+asm (".symver pow, pow@GLIBC_2.0");
+asm (".symver exp, exp@GLIBC_2.0");
+asm (".symver log, log@GLIBC_2.0");
+asm (".symver log2, log@GLIBC_2.0");
+#endif
+
+// I couldn't figure out what has changed in pow, exp, log in glibc 2.29.
+// Interestingly despite compiling with -fno-omit-frame-pointer, GCC
+// optimises the following to a jmp anyway.
+
+double __wrap_pow(double x, double y)
+{
+    return pow(x, y);
+}
+
+double __wrap_exp(double x)
+{
+    return exp(x);
+}
+
+double __wrap_log(double x)
+{
+    return log(x);
+}
+double __wrap_log2(double x)
+{
+    return log2(x);
+}
+#endif

--- a/include/glibc_compat.c
+++ b/include/glibc_compat.c
@@ -1,9 +1,6 @@
 /* This file is only used on GNU/Linux (ie glibc) when compiling with portable=1,
    in order to produce binaries that don't depend on functions only present
    in newer glibc versions.
-   Functions like fcntl are redirected by ld to __wrap_fcntl etc (see
-   SConscript), defined in this file, which are wrappers around a shadowed but
-   still present symbol in libc.so or libm.so.
    (The .symver lines below could instead be placed in a header included everywhere
    if we weren't linking to any libraries compiled without the header, eg libfb)
 
@@ -17,19 +14,13 @@
 #include <stdarg.h>
 #include <math.h>
 
-#ifdef HOST_64BIT
-// x86_64 glibc... I'm guessing ARM64, etc, has the same versioned symbols
+// x86_64 glibc -
+#define asm __asm__
 asm (".symver pow, pow@GLIBC_2.2.5");
 asm (".symver exp, exp@GLIBC_2.2.5");
 asm (".symver log, log@GLIBC_2.2.5");
-asm (".symver log2, log@GLIBC_2.2.5");
-#else
-// x86 glibc... I'm guessing ARM32, etc, has the same versioned symbols
-asm (".symver pow, pow@GLIBC_2.0");
-asm (".symver exp, exp@GLIBC_2.0");
-asm (".symver log, log@GLIBC_2.0");
-asm (".symver log2, log@GLIBC_2.0");
-#endif
+asm (".symver log2, log2@GLIBC_2.2.5");
+#undef asm
 
 // I couldn't figure out what has changed in pow, exp, log in glibc 2.29.
 // Interestingly despite compiling with -fno-omit-frame-pointer, GCC

--- a/include/glibc_compat.c
+++ b/include/glibc_compat.c
@@ -54,9 +54,9 @@ double __wrap_logf(double x)
     return logf(x);
 }
 
-double __wrap_powf(double x)
+double __wrap_powf(double x, double y)
 {
-    return powf(x);
+    return powf(x, y);
 }
 
 double __wrap_expf(double x)

--- a/include/vendor.c
+++ b/include/vendor.c
@@ -6,6 +6,9 @@
 #endif
 
 #include <stdbool.h>
+
+#include <glibc_compat.c>
+
 #include <jo_gif.h>
 
 #define OPTPARSE_IMPLEMENTATION
@@ -38,3 +41,5 @@
 #include <SDL.h>
 #define ABC_FIFO_IMPL
 #include <ABC_fifo.h>
+
+

--- a/include/vendor.c
+++ b/include/vendor.c
@@ -7,8 +7,6 @@
 
 #include <stdbool.h>
 
-#include <glibc_compat.c>
-
 #include <jo_gif.h>
 
 #define OPTPARSE_IMPLEMENTATION


### PR DESCRIPTION
Follows the instructions from [#189] to make linux builds backwards compatible, even if compiled against newer versions of GLIBC (At least for now)