### PR TITLE
Added Canvas.font getter

### DIFF
--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -18,12 +18,12 @@ It contains the following classes:
 The `Canvas` class is the core api for graphical display.
 
 ### Fields
+#### `static font: String`
+This is the name of the default font used for `Canvas.print(str, x, y, color)`. You can set this to `Font.default` to return to the DOME built-in font.
 #### `static height: Number`
 This is the height of the canvas/viewport, in pixels.
 #### `static width: Number`
 This is the width of the canvas/viewport, in pixels.
-#### `static font: String`
-This is the name of the canvas font as a string.
 
 ### Methods
 #### `static circle(x: Number, y: Number, r: Number, c: Color) `
@@ -89,10 +89,6 @@ Draw a filled rectangle with the top-left corner at (_x, y_), with a width of _w
 Resize the canvas to the given `width` and `height`, and reset the color of the canvas to `c`.
 If `c` isn't provided, we default to black.
 Resizing the canvas resets the "clipping region" to encompass the whole canvas, as if `Canvas.clip()` was called.
-
-### Instance Field
-#### `font: String`
-This sets the name of the default font used for `Canvas.print(str, x, y, color)`. You can set this to `Font.default` to return to the DOME built-in font.
 
 ## Color
 

--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -22,6 +22,8 @@ The `Canvas` class is the core api for graphical display.
 This is the height of the canvas/viewport, in pixels.
 #### `static width: Number`
 This is the width of the canvas/viewport, in pixels.
+#### `static font: String`
+This is the name of the canvas font as a string.
 
 ### Methods
 #### `static circle(x: Number, y: Number, r: Number, c: Color) `

--- a/src/modules/graphics.wren
+++ b/src/modules/graphics.wren
@@ -13,6 +13,8 @@ class Canvas {
       Fiber.abort("Default font must be a font name")
     }
   }
+  
+  static font {__defaultFont}
 
   foreign static f_resize(width, height, color)
   static offset() { offset(0, 0) }

--- a/src/modules/graphics.wren
+++ b/src/modules/graphics.wren
@@ -14,7 +14,7 @@ class Canvas {
     }
   }
   
-  static font {__defaultFont}
+  static font { __defaultFont }
 
   foreign static f_resize(width, height, color)
   static offset() { offset(0, 0) }


### PR DESCRIPTION
This makes it possible to do `Canvas.font` to get the current font name as a string.