### PR TITLE
Updated the math library to use inbuilt functions

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,3 +10,4 @@ We'd like to thank the following people for their contributions.
   * Chayim Refael Friedman [https://github.com/ChayimFriedman2]
   * Benjamin Stigsen [https://github.com/benstigsen]
   * Alexandru Badiu, aka voidberg [https://github.com/voidberg]
+  * Aayush Kashyap [https://github.com/TheKing0x9]

--- a/docs/modules/math.md
+++ b/docs/modules/math.md
@@ -38,7 +38,7 @@ Returns the arctan of `n`.
 #### `ceil(n: Number): Number`
 Rounds `n` up to the next largest integer value.
 
-#### `clamp(number : Number, min : Number, max : Number)`
+#### `clamp(number : Number, min : Number, max : Number) : Number`
 Clamps `number` between `min` and `max`.
 
 #### `cos(n: Number): Number`

--- a/docs/modules/math.md
+++ b/docs/modules/math.md
@@ -38,6 +38,9 @@ Returns the arctan of `n`.
 #### `ceil(n: Number): Number`
 Rounds `n` up to the next largest integer value.
 
+#### `clamp(number : Number, min : Number, max : Number)`
+Clamps `number` between `min` and `max`.
+
 #### `cos(n: Number): Number`
 Returns the cosine of `n`.
 

--- a/src/modules/math.wren
+++ b/src/modules/math.wren
@@ -60,21 +60,13 @@ class Math {
   static max(a, b) {
     assertNum(a)
     assertNum(b)
-    if (a > b) {
-      return a
-    } else {
-      return b
-    }
+    return a.max(b)
   }
 
   static min(a, b) {
     assertNum(a)
     assertNum(b)
-    if (a < b) {
-      return a
-    } else {
-      return b
-    }
+    return a.min(b)
   }
 
   static sign(a) {
@@ -97,11 +89,14 @@ class Math {
       a = b
       b = swap
     }
-    if (b < c) {
-      return b
-    } else {
-      return c
-    }
+    return b.min(c)
+  }
+  
+  static clamp(number, min, max) {
+    assertNum(number)
+    assertNum(min)
+    assertNum(max)
+    return number.clamp(min, max)
   }
 
   static lerp(low, value, high) {


### PR DESCRIPTION
This pull updates the Dome Math library to use the inbuilt functions for min, max and clamp., The changed functions are 

- Math.min (a, b)
- Math.max(a, b)
- Math.mid (a, b, c)

Also, a new function Math.clamp (number, min, max ) has been added which is a wrapper around the inbuilt Num.clamp function