### PR TITLE
Clip Crash Fix

### DIFF
--- a/src/modules/graphics.c
+++ b/src/modules/graphics.c
@@ -292,8 +292,8 @@ CANVAS_clip(WrenVM* vm) {
   DOME_RECT rect = {
     .x = x,
     .y = y,
-    .w = min(width, w),
-    .h = min(height, h)
+    .w = min(width - x, w),
+    .h = min(height - y, h)
   };
   engine->canvas.clip = rect;
 }


### PR DESCRIPTION
When setting the clip region, we didn't guard against the clip region overflowing the canvas buffer correctly. This corrects the issue.