### PR TITLE
Fixes a bug in the circle example

### DIFF
--- a/examples/circle/main.wren
+++ b/examples/circle/main.wren
@@ -19,6 +19,10 @@ class Main {
     }
     if (Keyboard["down"].down) {
       _size = _size - 1
+
+      if (_size < 0) {
+        _size = 0
+      }
     }
   }
 


### PR DESCRIPTION
I know this is the smallest of changes, but I was looking through the example and got an unexpected crash due to the circle's size being negative.

So I thought I would go ahead and create a PR to fix that.