### PR TITLE
simplify main.wren

### DIFF
--- a/main.wren
+++ b/main.wren
@@ -1,9 +1,9 @@
 import "graphics" for Canvas, Color
 
 class Game {
-  init() {}
-  update() {}
-  draw(dt) {
+  static init() {}
+  static update() {}
+  static draw(dt) {
     Canvas.print("DOME Installed Successfully.", 10, 10, Color.white)
   }
 }

--- a/main.wren
+++ b/main.wren
@@ -1,12 +1,9 @@
 import "graphics" for Canvas, Color
 
-class Main {
-  construct new() {}
+class Game {
   init() {}
   update() {}
   draw(dt) {
     Canvas.print("DOME Installed Successfully.", 10, 10, Color.white)
   }
 }
-
-var Game = Main.new()


### PR DESCRIPTION
Wren doesn't seem to care whether a method comes from an instance of a class or the class itself, so I made the main file more concise. it avoids the need to instantiate a class and to put an empty constructor method in it, and having the game on the class itself is more akin to how Wren works