### PR TITLE
Add cli flag to choose screen window is opened on

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -251,7 +251,7 @@ ENGINE_start(ENGINE* engine) {
   }
 
   //Create window
-  engine->window = SDL_CreateWindow("DOME", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, SCREEN_WIDTH, SCREEN_HEIGHT, windowFlags);
+  engine->window = SDL_CreateWindow("DOME", SDL_WINDOWPOS_CENTERED_DISPLAY(SCREEN), SDL_WINDOWPOS_CENTERED_DISPLAY(SCREEN), SCREEN_WIDTH, SCREEN_HEIGHT, windowFlags);
   if(engine->window == NULL)
   {
     char* message = "Window could not be created! SDL_Error: %s\n";

--- a/src/game.c
+++ b/src/game.c
@@ -317,7 +317,7 @@ int DOME_begin(ENGINE* engine, char* entryPath) {
   initMethod = NULL;
   engine->initialized = true;
 
-  SDL_SetWindowPosition(engine->window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+  SDL_SetWindowPosition(engine->window, SDL_WINDOWPOS_CENTERED_DISPLAY(SCREEN), SDL_WINDOWPOS_CENTERED_DISPLAY(SCREEN));
   SDL_ShowWindow(engine->window);
 
   loop.lag = loop.MS_PER_FRAME;

--- a/src/main.c
+++ b/src/main.c
@@ -78,6 +78,7 @@ global_variable WrenHandle* gamepadClass = NULL;
 global_variable WrenHandle* updateInputMethod = NULL;
 
 // These are set by cmd arguments
+global_variable bool SCREEN = 0;
 #ifdef DEBUG
 global_variable bool DEBUG_MODE = true;
 #else
@@ -176,6 +177,7 @@ printUsage(ENGINE* engine) {
   ENGINE_printLog(engine, "  nest     Bundle a project into a single file.\n");
   ENGINE_printLog(engine, "\nOptions: \n");
   ENGINE_printLog(engine, "  -b --buffer=<buf>   Set the audio buffer size (default: 11)\n");
+  ENGINE_printLog(engine, "  -s --screen=<num>   Set the screen which window will be opened (default: 0)\n");
 #ifdef __MINGW32__
   ENGINE_printLog(engine, "  -c --console        Opens a console window for development.\n");
 #endif
@@ -305,6 +307,7 @@ int main(int argc, char* argv[])
     {"console", 'c', OPTPARSE_NONE},
 #endif
     {"buffer", 'b', OPTPARSE_REQUIRED},
+    {"screen", 's', OPTPARSE_REQUIRED},
     {"debug", 'd', OPTPARSE_NONE},
     {0}
   };
@@ -353,6 +356,12 @@ int main(int argc, char* argv[])
           {
             DEBUG_MODE = true;
             ENGINE_printLog(&engine, "Debug Mode enabled\n");
+          } break;
+        case 's':
+          {
+            int screen = atoi(options.optarg);
+            SCREEN = screen;
+            ENGINE_printLog(&engine, "Screen force enabled\n");
           } break;
         case 'h':
           {


### PR DESCRIPTION
What does this PR do?
- Adds cli flag to dome executable to control screen that it opens to

Usage 
`dome -s 1` opens dome on second screen