### PR TITLE
Add display switching api for dome

### DIFF
--- a/docs/modules/dome.md
+++ b/docs/modules/dome.md
@@ -80,6 +80,9 @@ Returns the generic name of the operating system or platform, where possible.
 #### `time: Number`
 Returns the integer number of seconds since the unix epoch (1st January 1970).
 
+#### `displayCount: Number`
+Returns the integer number of displays on the system.
+
 ## Process
 
 ### Static Fields
@@ -143,6 +146,10 @@ Default is `false`.
 #### `static height: Number`
 
 This is the height of the window/viewport, in pixels.
+
+#### `static display: Number`
+
+This is the display window is rendered on. Default is `0` which is users primary/main display. When going out of bounds (less than `0` or more than number of displays) will automatically loop back around 
 
 #### `static integerScale: Boolean`
 

--- a/examples/display/main.wren
+++ b/examples/display/main.wren
@@ -1,0 +1,67 @@
+import "graphics" for Canvas, Color, Font
+import "dome" for Log, Window, Platform, Process
+import "input" for Mouse
+class Main {
+  construct new() {
+    Window.display = 0
+    _leftButtonColor = Color.white
+    _rightButtonColor = Color.white
+    _fullScreenButtonColor = Color.white
+    _quitButtonColor = Color.white
+    _buttonPressed = false
+  }
+  init() {
+    
+  }
+  update() {
+    _leftButtonColor = Color.white
+    _rightButtonColor = Color.white
+    _fullscreenButtonColor = Color.white
+    _quitButtonColor = Color.white
+    if(Mouse.x>=10 && Mouse.y>=15 && Mouse.x <= 15 && Mouse.y <= 28) {
+      _leftButtonColor = Color.red
+      if(!_buttonPressed && Mouse.isButtonPressed("left") ) {
+        Window.display = Window.display - 1
+        _buttonPressed = true
+      }
+    
+    }
+
+    if (Mouse.x>=105 && Mouse.y>=15 && Mouse.x <= 110 && Mouse.y <= 28) {
+       _rightButtonColor = Color.red
+      if(!_buttonPressed && Mouse.isButtonPressed("left")) {
+      
+        Window.display = Window.display + 1
+        _buttonPressed = true
+      }
+    }
+
+    if(Mouse.x>=10 && Mouse.y>=30 && Mouse.x <= 100 && Mouse.y <= 38) {
+      _fullscreenButtonColor = Color.red
+      if(!_buttonPressed && Mouse.isButtonPressed("left")) {
+        Window.fullscreen = !Window.fullscreen
+        _buttonPressed = true
+      }
+    }
+    if(Mouse.x>=10 && Mouse.y>=40 && Mouse.x <= 60 && Mouse.y <= 48) {
+      _quitButtonColor = Color.red
+      if(!_buttonPressed && Mouse.isButtonPressed("left")) {
+        Process.exit()
+        _buttonPressed = true
+      }
+    }
+    if(_buttonPressed && !Mouse.isButtonPressed("left")){
+      _buttonPressed = false
+    }
+  }
+  draw(dt) {
+    Canvas.cls()
+    Canvas.print("<", 10, 20, _leftButtonColor)
+    Canvas.print("Display: %(Window.display)", 20, 20, Color.white)
+    Canvas.print(">", 105, 20, _rightButtonColor)
+    Canvas.print("Fullscreen", 20, 30, _fullscreenButtonColor)
+    Canvas.print("Quit", 20, 40, _quitButtonColor)
+  }
+}
+
+var Game = Main.new()

--- a/src/engine.c
+++ b/src/engine.c
@@ -251,7 +251,7 @@ ENGINE_start(ENGINE* engine) {
   }
 
   //Create window
-  engine->window = SDL_CreateWindow("DOME", SDL_WINDOWPOS_CENTERED_DISPLAY(SCREEN), SDL_WINDOWPOS_CENTERED_DISPLAY(SCREEN), SCREEN_WIDTH, SCREEN_HEIGHT, windowFlags);
+  engine->window = SDL_CreateWindow("DOME", SDL_WINDOWPOS_CENTERED_DISPLAY(DISPLAY), SDL_WINDOWPOS_CENTERED_DISPLAY(DISPLAY), SCREEN_WIDTH, SCREEN_HEIGHT, windowFlags);
   if(engine->window == NULL)
   {
     char* message = "Window could not be created! SDL_Error: %s\n";

--- a/src/game.c
+++ b/src/game.c
@@ -317,7 +317,7 @@ int DOME_begin(ENGINE* engine, char* entryPath) {
   initMethod = NULL;
   engine->initialized = true;
 
-  SDL_SetWindowPosition(engine->window, SDL_WINDOWPOS_CENTERED_DISPLAY(SCREEN), SDL_WINDOWPOS_CENTERED_DISPLAY(SCREEN));
+  SDL_SetWindowPosition(engine->window, SDL_WINDOWPOS_CENTERED_DISPLAY(DISPLAY), SDL_WINDOWPOS_CENTERED_DISPLAY(DISPLAY));
   SDL_ShowWindow(engine->window);
 
   loop.lag = loop.MS_PER_FRAME;

--- a/src/main.c
+++ b/src/main.c
@@ -78,7 +78,7 @@ global_variable WrenHandle* gamepadClass = NULL;
 global_variable WrenHandle* updateInputMethod = NULL;
 
 // These are set by cmd arguments
-global_variable bool SCREEN = 0;
+global_variable int SCREEN = 0;
 #ifdef DEBUG
 global_variable bool DEBUG_MODE = true;
 #else

--- a/src/main.c
+++ b/src/main.c
@@ -78,7 +78,7 @@ global_variable WrenHandle* gamepadClass = NULL;
 global_variable WrenHandle* updateInputMethod = NULL;
 
 // These are set by cmd arguments
-global_variable int SCREEN = 0;
+global_variable int DISPLAY = 0;
 #ifdef DEBUG
 global_variable bool DEBUG_MODE = true;
 #else
@@ -359,9 +359,7 @@ int main(int argc, char* argv[])
           } break;
         case 's':
           {
-            int screen = atoi(options.optarg);
-            SCREEN = screen;
-            ENGINE_printLog(&engine, "Screen force enabled\n");
+            DISPLAY = atoi(options.optarg);
           } break;
         case 'h':
           {

--- a/src/modules/dome.c
+++ b/src/modules/dome.c
@@ -115,6 +115,33 @@ WINDOW_getHeight(WrenVM* vm) {
 }
 
 internal void
+WINDOW_setDisplay(WrenVM* vm) {
+  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
+  ASSERT_SLOT_TYPE(vm, 1, NUM, "display");
+  int32_t display = wrenGetSlotDouble(vm, 1);
+  if(display < 0) {
+    display = SDL_GetNumVideoDisplays() - 1;
+  }
+  DISPLAY = display;
+  uint32_t flags = SDL_GetWindowFlags(engine->window);
+  bool fullscreen = (flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0;
+  if(fullscreen) {
+    SDL_SetWindowFullscreen(engine->window, SDL_WINDOW_SHOWN);
+  }
+  SDL_SetWindowPosition(engine->window, SDL_WINDOWPOS_CENTERED_DISPLAY(DISPLAY), SDL_WINDOWPOS_CENTERED_DISPLAY(DISPLAY));
+  if(fullscreen) {
+    SDL_SetWindowFullscreen(engine->window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+  }
+}
+
+internal void
+WINDOW_getDisplay(WrenVM* vm) {
+  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
+  int display = SDL_GetWindowDisplayIndex(engine->window);
+  wrenSetSlotDouble(vm, 0, display);
+}
+
+internal void
 WINDOW_setTitle(WrenVM* vm) {
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
   ASSERT_SLOT_TYPE(vm, 1, STRING, "title");

--- a/src/modules/dome.wren
+++ b/src/modules/dome.wren
@@ -115,6 +115,8 @@ class Process {
 
 
 class Window {
+  foreign static display=(value)
+  foreign static display
   foreign static title=(value)
   foreign static title
   foreign static vsync=(value)

--- a/src/modules/platform.c
+++ b/src/modules/platform.c
@@ -9,3 +9,9 @@ PLATFORM_getName(WrenVM* vm) {
   wrenEnsureSlots(vm, 1);
   wrenSetSlotString(vm, 0, SDL_GetPlatform());
 }
+
+internal void
+PLATFORM_getDisplayCount(WrenVM* vm) {
+  int displays = SDL_GetNumVideoDisplays();
+  wrenSetSlotDouble(vm, 0, displays);
+}

--- a/src/modules/platform.wren
+++ b/src/modules/platform.wren
@@ -1,4 +1,5 @@
 class Platform {
   foreign static time
   foreign static name
+  foreign static displayCount
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -184,6 +184,8 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_addFunction(&engine->moduleMap, "dome", "static Log.print(_,_,_)", LOG_print);
   MAP_addFunction(&engine->moduleMap, "dome", "static Log.f_level=(_)", LOG_setLevel);
   MAP_addFunction(&engine->moduleMap, "dome", "static Log.level", LOG_getLevel);
+  MAP_addFunction(&engine->moduleMap, "dome", "static Window.display=(_)", WINDOW_setDisplay);
+  MAP_addFunction(&engine->moduleMap, "dome", "static Window.display", WINDOW_getDisplay);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.title=(_)", WINDOW_setTitle);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.title", WINDOW_getTitle);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.integerScale=(_)", WINDOW_setIntegerScale);
@@ -338,6 +340,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   // Platform
   MAP_addFunction(&engine->moduleMap, "platform", "static Platform.time", PLATFORM_getTime);
   MAP_addFunction(&engine->moduleMap, "platform", "static Platform.name", PLATFORM_getName);
+  MAP_addFunction(&engine->moduleMap, "platform", "static Platform.displayCount", PLATFORM_getDisplayCount);
   MAP_lockModule(&engine->moduleMap, "platform");
 
   // Plugin


### PR DESCRIPTION
- Add `Window.display` and `Process.displayCount`
- Add Docs
- Add Example
- Made error in previous PR where added flag for screen switching by making it boolean effectivly making it so that you can move only to screens 0 and 1. Now can open window on other screens as well.